### PR TITLE
Maintain exising deck state when adding/removing decks

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -299,16 +299,16 @@ function create_input(type, name, value, text)
     return listitem;
 }
 
-function apply_deck_selection(decks, preserveExistingDeckState)
+function apply_deck_selection(decks, preserve_existing_deck_state)
 {
     var container = document.getElementById("tableau");
 
     var decks_to_remove = visible_decks.filter(function(deck) {
-        return !preserveExistingDeckState || decks.indexOf(deck) === -1;
+        return !preserve_existing_deck_state || decks.indexOf(deck) === -1;
     });
 
     var decks_to_add = decks.filter(function(deck) {
-        return !preserveExistingDeckState || visible_decks.indexOf(deck) === -1;
+        return !preserve_existing_deck_state || visible_decks.indexOf(deck) === -1;
     });
 
     decks_to_remove.forEach(function(deck) { deck.discard_deck(); });

--- a/logic.js
+++ b/logic.js
@@ -299,27 +299,23 @@ function create_input(type, name, value, text)
     return listitem;
 }
 
-function apply_deck_selection(decks)
+function apply_deck_selection(decks, preserveExistingDeckState)
 {
     var container = document.getElementById("tableau");
 
-    select(
-        visible_decks,
-        function(visible_deck) {
-            return !any(decks, function(d) { return d.name === visible_deck.name; });
-        }
-    ).forEach(function(deck) { deck.discard_deck(); });
+    var decks_to_remove = visible_decks.filter(function(deck) {
+        return !preserveExistingDeckState || decks.indexOf(deck) === -1;
+    });
 
-    for (var i = 0; i < decks.length; i++)
-    {
-        var deck = decks[i];
+    var decks_to_add = decks.filter(function(deck) {
+        return !preserveExistingDeckState || visible_decks.indexOf(deck) === -1;
+    });
 
-        if (any(visible_decks, function(visible_deck) { return visible_deck.name === deck.name; })) {
-            // This deck is already on the tableau.
-            continue;
-        }
+    decks_to_remove.forEach(function(deck) { deck.discard_deck(); });
 
+    decks_to_add.forEach(function(deck) {
         var deck_space = document.createElement("div");
+
         deck_space.className = "card-container";
 
         container.appendChild(deck_space);
@@ -340,7 +336,7 @@ function apply_deck_selection(decks)
         }.bind(deck, deck_space);
 
         visible_decks.push(deck);
-    }
+    });
 
     // Rescale card text if necessary
     refresh_ui(decks);
@@ -424,11 +420,11 @@ function init()
         var selected_deck_names = get_checkbox_selection(checkboxes);
         clear_list(selected_decks);
         selected_deck_names.map( function(name) { selected_decks.push(decks[name]); } );
-        apply_deck_selection(selected_decks);
+        apply_deck_selection(selected_decks, true);
     };
     applyscenariobtn.onclick = function()
     {
-        apply_deck_selection(selected_decks);
+        apply_deck_selection(selected_decks, false);
     };
 
     window.onresize = refresh_ui.bind(null, selected_decks);

--- a/logic.js
+++ b/logic.js
@@ -315,7 +315,6 @@ function apply_deck_selection(decks, preserveExistingDeckState)
 
     decks_to_add.forEach(function(deck) {
         var deck_space = document.createElement("div");
-
         deck_space.className = "card-container";
 
         container.appendChild(deck_space);
@@ -324,7 +323,7 @@ function apply_deck_selection(decks, preserveExistingDeckState)
         reshuffle(deck);
         deck_space.onclick = draw_card.bind(null, deck);
 
-        deck.discard_deck = function(deck_element)
+        deck.discard_deck = function()
         {
             var index = visible_decks.indexOf(this);
 
@@ -332,8 +331,8 @@ function apply_deck_selection(decks, preserveExistingDeckState)
                 visible_decks.splice(index, 1);
             }
 
-            container.removeChild(deck_element);
-        }.bind(deck, deck_space);
+            container.removeChild(deck_space);
+        };
 
         visible_decks.push(deck);
     });

--- a/util.js
+++ b/util.js
@@ -22,3 +22,18 @@ function toggle_class(element, class_name, enable_class)
     }
 }
 
+function select(array, predicate) {
+    var ret = [];
+
+    array.forEach(function(value) {
+        if (predicate(value)) {
+            ret.push(value);
+        }
+    });
+
+    return ret;
+}
+
+function any(array, predicate) {
+    return select(array, predicate).length > 0;
+}

--- a/util.js
+++ b/util.js
@@ -22,18 +22,3 @@ function toggle_class(element, class_name, enable_class)
     }
 }
 
-function select(array, predicate) {
-    var ret = [];
-
-    array.forEach(function(value) {
-        if (predicate(value)) {
-            ret.push(value);
-        }
-    });
-
-    return ret;
-}
-
-function any(array, predicate) {
-    return select(array, predicate).length > 0;
-}


### PR DESCRIPTION
* Prevent existing decks from resetting/reshuffling when adding/removing decks to/from the tableau. This change adds a global `visible_decks` variable to track which decks are currently present on the tableau and takes this into account when applying a new deck selection.
* Fix a closure issue in `apply_deck_selection` allowing the use of `deck.discard_deck` to remove decks from the tableau instead of clearing `container.innerHTML`.
* Add some array utilities to make it easier to search and filter deck arrays.

Fixes #12.

@johreh Please review. I added `select` and `any` while trying to avoid some of the more modern array functions which aren't supported in IE, but then I realized that it looks like the app already doesn't run in IE. :) So if you don't care about supporting IE, I could do some further revision and improve readability here.

Also, thanks for putting this app together! You've done a great job here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johreh/gloomycompanion/17)
<!-- Reviewable:end -->
