### PR TITLE
Fix some scenario decks that were causing a failure

### DIFF
--- a/scenarios.js
+++ b/scenarios.js
@@ -588,7 +588,7 @@ SCENARIO_DEFINITIONS =
         },
         { name: "#75 Overgrown Graveyard"
         , decks:
-            [ "Living bones"
+            [ "Living Bones"
             , "Living Corpse"
             , "Living Spirit"
             ]
@@ -605,7 +605,7 @@ SCENARIO_DEFINITIONS =
         , decks:
             [ "Guard"
             , "Archer"
-            , "Golem"
+            , "Stone Golem"
             , "Hound"
             ]
         },
@@ -645,7 +645,7 @@ SCENARIO_DEFINITIONS =
         { name: "#82 Burning Mountain"
         , decks:
             [ "Earth Demon"
-            , "Fire Demon"
+            , "Flame Demon"
             , "Stone Golem"
             ]
         },


### PR DESCRIPTION
These three typos were causing an error if a user selected any of those scenarios.

I have no scenario book on my own, so I can't verify that the data is the exact one, but I just changed it to the closest monster.

I verify it adding this code to init, forcing every deck to load. There were no other errors!

   ```
 for (var i=0; i < SCENARIO_DEFINITIONS.length; i++)
    {
        console.log(SCENARIO_DEFINITIONS[i].name);
        console.log(SCENARIO_DEFINITIONS[i].decks);
        var selected_decks = SCENARIO_DEFINITIONS[i].decks.map( function(name) { return decks[name]; } );
        decklist.set_selection(selected_decks.map( function(deck) { return deck.name; } ));
        apply_deck_selection(selected_decks, false);
    }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johreh/gloomycompanion/23)
<!-- Reviewable:end -->
