### PR TITLE
Hide Scenario names, as requested by Isaac Childres, and add a spinne…

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -735,33 +735,35 @@ function ScenarioList(scenarios)
     var scenariolist = {};
     scenariolist.ul = document.createElement("ul");
     scenariolist.ul.className = "selectionlist";
-    scenariolist.radios = [];
+    scenariolist.spinner = null;
     scenariolist.decks = {};
 
     for (var i = 0; i < scenarios.length; i++)
     {
         var scenario = scenarios[i];
-        var listitem = document.createElement("li");
-        var dom_dict = create_input("radio", "scenario", scenario.name, scenario.name);
-
-        listitem.appendChild(dom_dict.root);
-        scenariolist.ul.appendChild(listitem);
-        scenariolist.radios.push(dom_dict.input);
-        scenariolist.decks[scenario.name] = scenario.decks;
+        scenariolist.decks[i] = scenario.decks;
     }
+
+    var listitem = document.createElement("li");
+    listitem.innerText = "Select scenario number";
+    scenariolist.ul.appendChild(listitem);
+
+    var scenario_spinner = create_input("number", "scenario_number", "1", "");
+    scenario_spinner.input.min = 1;
+    scenario_spinner.input.max = scenarios.length;
+    scenariolist.ul.appendChild(scenario_spinner.input);
+    scenariolist.spinner = scenario_spinner.input;
 
     scenariolist.get_selection = function()
     {
-        return scenariolist.radios.filter(is_checked).map(input_value);
+        // We're using the scenario index that is zero-based, but the scenario list is 1-based
+        var current_value = scenariolist.spinner.value - 1;
+        return (current_value > scenarios.length) ? scenarios.length + 1 : current_value;
     }
 
     scenariolist.get_scenario_decks = function()
     {
-        var selected_scenarios = this.get_selection();
-        var selected_decks = concat_arrays(selected_scenarios.map( function(scenario_name) {
-            return ((scenario_name in this.decks) ? this.decks[scenario_name] : []);
-        }.bind(this)));
-        return selected_decks;
+        return this.decks[this.get_selection()];
     }
 
     return scenariolist;

--- a/scenarios.js
+++ b/scenarios.js
@@ -1,6 +1,6 @@
 SCENARIO_DEFINITIONS =
     [   { name: "#1 Black Barrow"
-        , decks: 
+        , decks:
             [ "Guard"
             , "Archer"
             , "Living Bones" ]
@@ -15,7 +15,7 @@ SCENARIO_DEFINITIONS =
         },
         { name: "#3 Inox Encampment"
         , decks:
-            [ "Guard" 
+            [ "Guard"
             , "Archer"
             , "Shaman" ]
         },
@@ -435,13 +435,11 @@ SCENARIO_DEFINITIONS =
             , "Harrower Infester"
             ]
         },
-/*
+        //TODO Show message that this is random, use deck tab instead
         { name: "#55 Foggy Thicket"
         , decks:
-            [ "Random"
-            ]
+            [ ]
         },
-*/
         { name: "#56 Bandit's Wood"
         , decks:
             [ "Hound"


### PR DESCRIPTION
Used the Regex: (In case we have to use it again)
	(name: ")(#\d*)([^\n]*)
	number: "$2"\n        , name: "$2$3

As requested by Isaac at https://boardgamegeek.com/thread/1688250/please-read-request-designerpublisher-regarding-sp, I'm hiding the scenario names. They are still accessible through the code, in case we want to use them after the selection.

The result can be checked here https://gyazo.com/896d3d6de11b54e0e7f01ec04101354a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johreh/gloomycompanion/28)
<!-- Reviewable:end -->
