### PR TITLE
Fix the clipping when drawing to cards

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -337,14 +337,14 @@
 
 .card.modifier.front.left img.cover
 {
-    left:                       -30%;
-    clip-path:                  inset(0% 20% 0% 20%);
+    left:                       -25%;
+    clip-path:                  inset(0% 24.5% 0% 24.5%);
 }
 
 .card.modifier.front.right img.cover
 {
-    left:                       30%;
-    clip-path:                  inset(0% 20% 0% 20%);
+    left:                       25%;
+    clip-path:                  inset(0% 24.5% 0% 24.5%);
 }
 
 .card ul


### PR DESCRIPTION
I just realised that, after we're cropping the cards to a card-container size, drawing two cards look weird. I just made it as even as possible. Here is the result: 
Before the change (Left) - After the change (Right).
<img width="1124" alt="screen shot 2017-03-29 at 22 03 19" src="https://cloud.githubusercontent.com/assets/14745341/24474071/c31a0edc-14cb-11e7-9964-bd7ac5cfaa3b.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johreh/gloomycompanion/29)
<!-- Reviewable:end -->
