### PR TITLE
Fix +- clipping from issue #30

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -58,7 +58,7 @@
     list-style:                 none;
 
     border:                     none;
-    overflow:                   hidden;
+    overflow:                   visible;
     outline:                    none;
 
     display:                    -webkit-flex;


### PR DESCRIPTION
It fixes the clipping issue for me (https://github.com/johreh/gloomycompanion/issues/30), and I've tried with several sizes/ratios and using the overflow doesn't overlap the images. It looks good!

Feel free to use my branch to check it before.

Edit: Wrong image
<img width="425" alt="screen shot 2017-03-29 at 23 18 21" src="https://cloud.githubusercontent.com/assets/14745341/24477164/4bdf971e-14d6-11e7-99f8-efcf60f6ab35.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johreh/gloomycompanion/31)
<!-- Reviewable:end -->
