### PR TITLE
Fix shuffle as requested on Issue#39

### DIFF
--- a/util.js
+++ b/util.js
@@ -3,7 +3,8 @@ function shuffle_list(l)
 {
     for (var i = 0; i < l.length; i++)
     {
-        var switch_index = Math.floor(Math.random() * l.length);
+        // Based on https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#Implementation_errors
+        var switch_index = i + Math.floor(Math.random() * (l.length - i));
         var tmp = l[switch_index];
         l[switch_index] = l[i];
         l[i] = tmp;


### PR DESCRIPTION
Related to https://github.com/johreh/gloomycompanion/issues/39  I have been trying it several times debugging the initiative of the card, and every card can be chosen in any position. I haven't done an exhaustive percentage test nor anything, but apparently it is a common implementation issue described in https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#Implementation_errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johreh/gloomycompanion/40)
<!-- Reviewable:end -->
