### PR TITLE
Fix Modifier deck for Safari

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -116,10 +116,16 @@
 .counter-icon.shuffle
 {
     background-repeat:          no-repeat;
-    background-position:        50% 50%;
+    background-position:        100% 50%;
     background-image:           url(images/shuffle-black.svg);
     background-size:            contain;
     cursor:                     pointer;
+
+    position:                   absolute;
+    left:                       0;
+    bottom:                     -40%;
+    width:                      20%;
+    height:                     20%;
 }
 
 .counter-icon .button
@@ -168,6 +174,7 @@
     background-position:        100% 50%;
     background-size:            contain;
     background-image:           url(images/draw-two.svg);
+    cursor:                     pointer;
 }
 
 .card-container.modifier
@@ -333,12 +340,14 @@
 {
     left:                       -25%;
     clip-path:                  inset(0% 24.5% 0% 24.5%);
+    -webkit-clip-path:          inset(0% 24.5% 0% 24.5%);
 }
 
 .card.modifier.front.right img.cover
 {
     left:                       25%;
     clip-path:                  inset(0% 24.5% 0% 24.5%);
+    -webkit-clip-path:          inset(0% 24.5% 0% 24.5%);
 }
 
 .card ul

--- a/cards.css
+++ b/cards.css
@@ -248,14 +248,14 @@
 {
     0%                          { z-index: -1; -webkit-transform: translateZ(3000px); }
     50%                         { z-index: -1; -webkit-transform: translateZ(3000px); }
-    100%                        { z-index: -4: }
+    100%                        { z-index: -4; }
 }
 
 @keyframes lift
 {
     0%                          { z-index: -1; }
     50%                         { z-index: -1; }
-    100%                        { z-index: -4: }
+    100%                        { z-index: -4; }
 }
 
 .card.front.pull

--- a/logic.js
+++ b/logic.js
@@ -233,11 +233,11 @@ function refresh_ui()
             tableau.style.fontSize  = font_pixel_size + "px";
             break;
         }
-        
+
     }
 }
 
-function reshuffle(deck, include_discards = true)
+function reshuffle(deck, include_discards)
 {
     if (include_discards)
     {
@@ -284,7 +284,7 @@ function flip_up_top_card(deck)
     deck.discard.unshift(card);
 }
 
-function send_to_discard(card, pull_animation = true)
+function send_to_discard(card, pull_animation)
 {
     card.ui.set_depth(-3);
 
@@ -303,7 +303,7 @@ function draw_ability_card(deck)
 {
     if (deck.must_reshuffle())
     {
-        reshuffle(deck);
+        reshuffle(deck, include_discards=true);
     }
     else
     {
@@ -328,7 +328,7 @@ function prevent_pull_animation(deck)
 function reshuffle_modifier_deck(deck)
 {
     deck.clean_discard_pile();
-    reshuffle(deck);
+    reshuffle(deck, include_discards=true);
 }
 
 function draw_modifier_card(deck)
@@ -465,9 +465,9 @@ function load_modifier_deck(number_bless, number_curses)
         repaint_modifier_deck(this);
     }.bind(deck);
 
-    deck.clean_advantage_deck = function( force_clean = false )
+    deck.clean_advantage_deck = function()
     {
-        if ((deck.advantage_to_clean || force_clean) && deck.discard[1])
+        if ((deck.advantage_to_clean) && deck.discard[1])
         {
             deck.advantage_to_clean = false;
             deck.discard[0].ui.removeClass("right");
@@ -580,7 +580,7 @@ function apply_deck_selection(decks, preserve_existing_deck_state)
         container.appendChild(deck_space);
 
         place_deck(deck, deck_space);
-        reshuffle(deck);
+        reshuffle(deck, include_discards=true);
         deck_space.onclick = draw_ability_card.bind(null, deck);
 
         deck.discard_deck = function()
@@ -685,7 +685,7 @@ function add_modifier_deck(container, deck)
     container.appendChild(modifier_container);
 
     place_deck(deck, deck_space);
-    reshuffle(deck);
+    reshuffle(deck, include_discards=true);
     deck_space.onclick = draw_modifier_card.bind(null, deck);
 
 }
@@ -783,7 +783,7 @@ function init()
 
     deckspage.insertAdjacentElement("afterbegin", decklist.ul);
     scenariospage.insertAdjacentElement("afterbegin", scenariolist.ul);
-    
+
     applydeckbtn.onclick = function()
     {
         var selected_deck_names = decklist.get_selection();

--- a/logic.js
+++ b/logic.js
@@ -233,7 +233,6 @@ function refresh_ui()
             tableau.style.fontSize  = font_pixel_size + "px";
             break;
         }
-
     }
 }
 
@@ -303,7 +302,7 @@ function draw_ability_card(deck)
 {
     if (deck.must_reshuffle())
     {
-        reshuffle(deck, include_discards=true);
+        reshuffle(deck, true);
     }
     else
     {
@@ -328,7 +327,7 @@ function prevent_pull_animation(deck)
 function reshuffle_modifier_deck(deck)
 {
     deck.clean_discard_pile();
-    reshuffle(deck, include_discards=true);
+    reshuffle(deck, true);
 }
 
 function draw_modifier_card(deck)
@@ -580,7 +579,7 @@ function apply_deck_selection(decks, preserve_existing_deck_state)
         container.appendChild(deck_space);
 
         place_deck(deck, deck_space);
-        reshuffle(deck, include_discards=true);
+        reshuffle(deck, true);
         deck_space.onclick = draw_ability_card.bind(null, deck);
 
         deck.discard_deck = function()
@@ -685,7 +684,7 @@ function add_modifier_deck(container, deck)
     container.appendChild(modifier_container);
 
     place_deck(deck, deck_space);
-    reshuffle(deck, include_discards=true);
+    reshuffle(deck, true);
     deck_space.onclick = draw_modifier_card.bind(null, deck);
 
 }


### PR DESCRIPTION
I think I have it! On safari 10.1 I can see all the buttons, they work, and I can see the clip-path from drawing two cards. It should be supported from iOS Safari 9.3... but I don't have an iPhone to test.

Please, give it a go and tell me! Lets fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johreh/gloomycompanion/41)
<!-- Reviewable:end -->
