### PR TITLE
Including monster stats

### DIFF
--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 #
-# Version Tue Mar 28 20:17:37 UTC 2017
+# Version Wed, Apr 19, 2017  7:14:29 PM
 #
 
 app.webmanifest
@@ -21,17 +21,17 @@ images/aoe-line-6-with-black.svg
 images/aoe-triangle-2-side.svg
 images/aoe-triangle-2-side-with-black.svg
 images/aoe-triangle-3-side-with-corner-black.svg
+images/attack.svg
 images/attack_mod_+0.jpg
-images/attack_mod_-1.jpg
 images/attack_mod_+1.jpg
-images/attack_mod_-2.jpg
 images/attack_mod_+2.jpg
+images/attack_mod_-1.jpg
+images/attack_mod_-2.jpg
 images/attack_mod_2x.jpg
 images/attack_mod_back.jpg
 images/attack_mod_bless.jpg
 images/attack_mod_curse.jpg
 images/attack_mod_null.jpg
-images/attack.svg
 images/back.jpg
 images/back.svg
 images/bless.svg
@@ -40,6 +40,7 @@ images/dark.svg
 images/disarm.svg
 images/draw-two.svg
 images/earth.svg
+images/elderDrake.special1Area.svg
 images/fire.svg
 images/fly.svg
 images/front.jpg
@@ -47,6 +48,7 @@ images/heal.svg
 images/ice.svg
 images/icon.png
 images/immobilize.svg
+images/inoxBodyguard.special1Area.svg
 images/invisibility.svg
 images/jump.svg
 images/light.svg
@@ -60,8 +62,10 @@ images/range.svg
 images/retaliate.svg
 images/settings.svg
 images/shield.svg
-images/shuffle-black.svg
 images/shuffle.svg
+images/shuffle-black.svg
+images/sightlessEye.special1Area.svg
+images/sightlessEye.special2Area.svg
 images/strengthen.svg
 images/stun.svg
 images/target.svg
@@ -71,6 +75,7 @@ index.html
 logic.js
 macros.js
 modifiers.js
+monster_stats.js
 Philosopher-Bold.ttf
 PirataOne-Gloomhaven.ttf
 scenarios.js

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 #
-# Version Wed, Apr 19, 2017  7:14:29 PM
+# Version Mon Apr 24 14:04:54 UTC 2017
 #
 
 app.webmanifest

--- a/cards.css
+++ b/cards.css
@@ -400,6 +400,11 @@
     font-size:                  75%;
 }
 
+.elite-color
+{
+    color:                      gold;
+}
+
 .icon
 {
     height:                     1.25em;

--- a/cards.js
+++ b/cards.js
@@ -1,44 +1,44 @@
-AVAILABLE_DECKS = 
-    [   {name: "Ancient Artillery", deck_name: "Ancient Artillery"}
-    ,   {name: "Bandit Archer", deck_name: "Archer"}
-    ,   {name: "City Archer", deck_name: "Archer"}
-    ,   {name: "Inox Archer", deck_name: "Archer"}
-    ,   {name: "Boss", deck_name: "Boss"}
-    ,   {name: "Cave Bear", deck_name: "Cave Bear"}
-    ,   {name: "Cultist", deck_name: "Cultist"}
-    ,   {name: "Deep Terror", deck_name: "Deep Terror"}
-    ,   {name: "Earth Demon", deck_name: "Earth Demon"}
-    ,   {name: "Flame Demon", deck_name: "Flame Demon"}
-    ,   {name: "Frost Demon", deck_name: "Frost Demon"}
-    ,   {name: "Giant Viperr", deck_name: "Giant Viper"}
-    ,   {name: "Bandit Guard", deck_name: "Guard"}
-    ,   {name: "City Guard", deck_name: "Guard"}
-    ,   {name: "Inox Guard", deck_name: "Guard"}
-    ,   {name: "Harrower Infester", deck_name: "Harrower Infester"}
-    ,   {name: "Hound", deck_name: "Hound"}
-    ,   {name: "Black Imp", deck_name: "Imp"}
-    ,   {name: "Forest Imp", deck_name: "Imp"}
-    ,   {name: "Living Bones", deck_name: "Living Bones"}
-    ,   {name: "Living Corpse", deck_name: "Living Corpse"}
-    ,   {name: "Lurker", deck_name: "Lurker"}
-    ,   {name: "Night Demon", deck_name: "Night Demon"}
-    ,   {name: "Ooze", deck_name: "Ooze"}
-    ,   {name: "Rending Drake", deck_name: "Rending Drake"}
-    ,   {name: "Savvas Icestorm", deck_name: "Savvas Icestorm"}
-    ,   {name: "Savvas Lavaflow", deck_name: "Savvas Lavaflow"}
-    ,   {name: "Inox Scout", deck_name: "Scout"}
-    ,   {name: "Vermling Scout", deck_name: "Scout"}
-    ,   {name: "Inox Shaman", deck_name: "Shaman"}
-    ,   {name: "Vermling Shaman", deck_name: "Shaman"}
-    ,   {name: "Spitting Drake", deck_name: "Spitting Drake"}
-    ,   {name: "Stone Golem", deck_name: "Stone Golem"}
-    ,   {name: "Sun Demon", deck_name: "Sun Demon"}
-    ,   {name: "Wind Demon", deck_name: "Wind Demon"}    
-];
+DECKS =
+    {   "Ancient Artillery":  {name: "Ancient Artillery", class: "Ancient Artillery"}
+    ,   "Bandit Archer":      {name: "Bandit Archer", class: "Archer"}
+    ,   "City Archer":        {name: "City Archer", class: "Archer"}
+    ,   "Inox Archer":        {name: "Inox Archer", class: "Archer"}
+    ,   "Boss":               {name: "Boss", class: "Boss"}
+    ,   "Cave Bear":          {name: "Cave Bear", class: "Cave Bear"}
+    ,   "Cultist":            {name: "Cultist", class: "Cultist"}
+    ,   "Deep Terror":        {name: "Deep Terror", class: "Deep Terror"}
+    ,   "Earth Demon":        {name: "Earth Demon", class: "Earth Demon"}
+    ,   "Flame Demon":        {name: "Flame Demon", class: "Flame Demon"}
+    ,   "Frost Demon":        {name: "Frost Demon", class: "Frost Demon"}
+    ,   "Giant Viper":        {name: "Giant Viper", class: "Giant Viper"}
+    ,   "Bandit Guard":       {name: "Bandit Guard", class: "Guard"}
+    ,   "City Guard":         {name: "City Guard", class: "Guard"}
+    ,   "Inox Guard":         {name: "Inox Guard", class: "Guard"}
+    ,   "Harrower Infester":  {name: "Harrower Infester", class: "Harrower Infester"}
+    ,   "Hound":              {name: "Hound", class: "Hound"}
+    ,   "Black Imp":          {name: "Black Imp", class: "Imp"}
+    ,   "Forest Imp":         {name: "Forest Imp", class: "Imp"}
+    ,   "Living Bones":       {name: "Living Bones", class: "Living Bones"}
+    ,   "Living Corpse":      {name: "Living Corpse", class: "Living Corpse"}
+    ,   "Living Spirit":      {name: "Living Spirit", class: "Living Spirit"}
+    ,   "Lurker":             {name: "Lurker", class: "Lurker"}
+    ,   "Night Demon":        {name: "Night Demon", class: "Night Demon"}
+    ,   "Ooze":               {name: "Ooze", class: "Ooze"}
+    ,   "Rending Drake":      {name: "Rending Drake", class: "Rending Drake"}
+    ,   "Savvas Icestorm":    {name: "Savvas Icestorm", class: "Savvas Icestorm"}
+    ,   "Savvas Lavaflow":    {name: "Savvas Lavaflow", class: "Savvas Lavaflow"}
+    ,   "Vermling Scout":   {name: "Vermling Scout", class: "Scout"}
+    ,   "Inox Shaman":        {name: "Inox Shaman", class: "Shaman"}
+    ,   "Vermling Shaman":    {name: "Vermling Shaman", class: "Shaman"}
+    ,   "Spitting Drake":     {name: "Spitting Drake", class: "Spitting Drake"}
+    ,   "Stone Golem":        {name: "Stone Golem", class: "Stone Golem"}
+    ,   "Sun Demon":          {name: "Sun Demon", class: "Sun Demon"}
+    ,   "Wind Demon":         {name: "Wind Demon", class: "Wind Demon"}
+};
 
-DECK_DEFINITONS = 
-[       
-        { name: "Ancient Artillery"
+DECK_DEFINITONS =
+[
+        { class: "Ancient Artillery"
         , cards:
             [ [false, "46", "* %attack% -1", "** %range% +2"]
             , [true,  "71", "* %attack% +0", "** All adjacent enemies suffer 2 damage"]
@@ -50,7 +50,7 @@ DECK_DEFINITONS =
             , [false, "46", "* %attack% -1 %aoe-triangle-2-side%", "** %immobilize%"]
             ]
         },
-        { name: "Archer"
+        { class: "Archer"
         , cards:
             [ [false, "16", "* %move% +1", "* %attack% -1"]
             , [false, "31", "* %move% +0", "* %attack% +0"]
@@ -62,7 +62,7 @@ DECK_DEFINITONS =
             , [true,  "29", "* %move% +0", "* %attack% -1", "** %range% +1", "** %immobilize%"]
             ]
         },
-        { name: "Boss"
+        { class: "Boss"
         , cards:
             [ [false, "11", "* Special 2"]
             , [false, "14", "* Special 2"]
@@ -74,7 +74,7 @@ DECK_DEFINITONS =
             , [false, "52", "* %move% -1", "* %attack% -1", "** %range% 3", "** %target% 2"]
             ]
         },
-        { name: "Cave Bear"
+        { class: "Cave Bear"
         , cards:
             [ [false, "13", "* %move% +1", "* %attack% -1"]
             , [false, "14", "* %move% -1", "* %attack% -1", "** %immobilize%"]
@@ -86,7 +86,7 @@ DECK_DEFINITONS =
             , [false, "03", "* %shield% 1", "* %retaliate% 2", "* %heal% 2", "** Self"]
             ]
         },
-        { name: "Cultist"
+        { class: "Cultist"
         , cards:
             [ [false, "10", "* %move% -1", "* %attack% -1", "* On Death:", "** %attack% +2 %aoe-circle-with-middle-black%"]
             , [false, "10", "* %move% -1", "* %attack% -1", "* On Death:", "** %attack% +2 %aoe-circle-with-middle-black%"]
@@ -98,7 +98,7 @@ DECK_DEFINITONS =
             , [false, "31", "* %move% -1", "* %heal% 3", "** %range% 3"]
             ]
         },
-        { name: "Deep Terror"
+        { class: "Deep Terror"
         , cards:
             [ [false, "65", "* %attack% +0", "** %range% 3", "** %target% 3", "** %curse%"]
             , [true,  "60", "* %attack% +0 %aoe-line-6-with-black%", "** %pierce% 3"]
@@ -110,7 +110,7 @@ DECK_DEFINITONS =
             , [false, "54", "* %wound% and %poison%", "** Target all adjacent enemies", "* %attack% +0", "** %range% 4"]
             ]
         },
-        { name: "Earth Demon"
+        { class: "Earth Demon"
         , cards:
             [ [true,  "40", "* %heal% 3", "** Self", "* %earth%%use_element%: <span class='small'>%immobilize% Target all enemies within %range% 3</span>"]
             , [true,  "42", "* %move% +1", "* %attack% -1"]
@@ -122,19 +122,19 @@ DECK_DEFINITONS =
             , [false, "87", "* %move% +0", "* %attack% -1 <div class='collapse'>%aoe-4-with-black%</div>", "* %any%%use_element%: %earth%"]
             ]
         },
-        { name: "Flame Demon"
+        { class: "Flame Demon"
         , cards:
             [ [false, "03", "* %move% +1", "* %attack% -1", "* %fire%"]
             , [false, "24", "* %move% +0", "* %attack% +0", "* %fire%"]
             , [true,  "46", "* %attack% +0", "** %fire%%use_element%:  %aoe-circle%"]
             , [false, "49", "* %attack% +0 %aoe-line-3-with-black%", "** %fire%%use_element%: +1 %attack%<br/>%wound%"]
             , [false, "67", "* %move% -1", "* %attack% +1", "** %range% -1", "* %fire%"]
-            , [false, "77", "* %attack% +0", "** Target all adjacent enemies", "* %ice%%use_element%:Flame Demon suffers 1 damage."]
+            , [false, "77", "* %attack% +0", "** Target all adjacent enemies", "** %ice%%use_element%:Flame Demon suffers 1 damage."]
             , [true,  "30", "* %fire%%use_element%: <span class='small'>All adjacent enemies suffer 2 damage.</span>", "* %move% +0", "* %attack% -2", "** %wound%", "** %target% 2"]
             , [false, "08", "* %move% -1", "* Create a 4 damage trap in an adjacent empty hex closest to an enemy", "* %any%%use_element%: %fire%"]
             ]
         },
-        { name: "Frost Demon"
+        { class: "Frost Demon"
         , cards:
             [ [false, "18", "* %immobilize%", "** Target all enemies within %range% 2", "* %ice%%use_element%: <span class='small'>%heal% 3<br/>Self</span>"]
             , [false, "38", "* %move% +1", "* %attack% -1"]
@@ -146,7 +146,7 @@ DECK_DEFINITONS =
             , [false, "18", "* %shield% 2", "* %move% +1", "* %fire%%use_element%: <span class='small'>Frost Demon suffers 1 damage</span>"]
             ]
         },
-        { name: "Giant Viper"
+        { class: "Giant Viper"
         , cards:
             [ [true,  "32", "* %move% +0", "* %attack% +0", "** Add +2 %attack% if the target is adjacent to any of the Giant Viper's allies."]
             , [true,  "32", "* %move% +0", "* %attack% +0", "** Add +2 %attack% if the target is adjacent to any of the Giant Viper's allies."]
@@ -158,7 +158,7 @@ DECK_DEFINITONS =
             , [false, "23", "* %move% -1", "* %attack% -1", "** %immobilize%", "* %attack% -1"]
             ]
         },
-        { name: "Guard"
+        { class: "Guard"
         , cards:
             [ [true,  "15", "* %shield% 1", "* %retaliate% 2"]
             , [false, "30", "* %move% +1", "* %attack% -1"]
@@ -170,7 +170,7 @@ DECK_DEFINITONS =
             , [true , "15", "* %shield% 1", "* %attack% +0", "** %poison%"]
             ]
         },
-        { name: "Harrower Infester"
+        { class: "Harrower Infester"
         , cards:
             [ [false, "38", "* %move% -1", "* %attack% +1", "** %target% 2"]
             , [false, "07", "* %move% +0", "* %attack% -1", "** %poison%", "* %dark%"]
@@ -182,7 +182,7 @@ DECK_DEFINITONS =
             , [true,  "07", "* %attack% -1", "** %range% 3", "** %muddle%", "* %heal% 4", "** Self"]
             ]
         },
-        { name: "Hound"
+        { class: "Hound"
         , cards:
             [ [false, "06", "* %move% -1", "* %attack% +0", "** %immobilize%"]
             , [false, "07", "* %move% +0", "* %muddle%", "** Target all adjacent enemies"]
@@ -194,7 +194,7 @@ DECK_DEFINITONS =
             , [false, "72", "* %attack% -1", "** %pierce% 2", "* %move% -2", "* %attack% -1", "** %pierce% 2"]
             ]
 		},
-        { name: "Imp"
+        { class: "Imp"
         , cards:
             [ [false, "05", "* %shield% 5", "* %heal% 1", "** Self"]
             , [false, "37", "* %move% +0", "* %attack% +0"]
@@ -206,7 +206,7 @@ DECK_DEFINITONS =
             , [false, "24", "* %strengthen%", "** Affect all allies within %range% 2", "* %muddle%", "** Target all enemies within %range% 2"]
             ]
         },
-        { name: "Living Bones"
+        { class: "Living Bones"
         , cards:
             [ [false, "64", "* %move% -1", "* %attack% +1"]
             , [true,  "20", "* %move% -2", "* %attack% +0", "* %heal% 2", "** Self"]
@@ -218,7 +218,7 @@ DECK_DEFINITONS =
             , [true,  "12", "* %shield% 1", "* %heal% 2", "** Self"]
             ]
         },
-        { name: "Living Corpse"
+        { class: "Living Corpse"
         , cards:
             [ [false, "21", "* %move% +1", "* %muddle% and %immobilize%", "** Target one adjacent enemy"]
             , [false, "47", "* %move% +1", "* %attack% -1"]
@@ -230,7 +230,7 @@ DECK_DEFINITONS =
             , [false, "32", "* %attack% +2", "** %push% 1", "* Living Corpse suffers 1 damage."]
             ]
         },
-        { name: "Living Spirit"
+        { class: "Living Spirit"
         , cards:
             [ [true,  "22", "* %move% -1", "* %attack% -1", "** %muddle%"]
             , [true,  "33", "* %move% +0", "* %attack% -1", "** Target all enemies within range"]
@@ -242,7 +242,7 @@ DECK_DEFINITONS =
             , [false, "67", "* %move% -1", "* %attack% +1", "** %ice%%use_element%: %stun%"]
             ]
         },
-        { name: "Lurker"
+        { class: "Lurker"
         , cards:
             [ [true,  "11", "* %shield% 1", "** %ice%%use_element%: %shield% 2 instead","* %wound%", "** Target all adjacent enemies"]
             , [false, "28", "* %move% +1", "* %attack% -1"]
@@ -254,7 +254,7 @@ DECK_DEFINITONS =
             , [true,  "23", "* %shield% 1", "* %move% +0", "* %attack% -1", "* %ice%"]
             ]
         },
-        { name: "Night Demon"
+        { class: "Night Demon"
         , cards:
             [ [false, "04", "* %move% +1", "* %attack% -1", "* %dark%"]
             , [false, "07", "* %move% +1", "* %attack% -1", "* %dark%%use_element%: %invisible%", "** Self"]
@@ -266,7 +266,7 @@ DECK_DEFINITONS =
             , [false, "15", "* %move% +0", "* %attack% -1", "* All adjacent enemies and allies suffer 1 damage.", "* %any%%use_element%: %dark%"]
             ]
         },
-        { name: "Ooze"
+        { class: "Ooze"
         , cards:
             [ [false, "36", "* %move% +1", "* %attack% -1"]
             , [false, "57", "* %move% +0", "* %attack% +0"]
@@ -278,7 +278,7 @@ DECK_DEFINITONS =
             , [false, "66", "* %move% -1", "* %loot% 1", "* %heal% 2", "** Self"]
             ]
         },
-        { name: "Rending Drake"
+        { class: "Rending Drake"
         , cards:
             [ [false, "12", "* %move% +1", "* %attack% -1"]
             , [true,  "13", "* %attack% -1", "* %move% -1", "* %attack% -1"]
@@ -290,7 +290,7 @@ DECK_DEFINITONS =
             , [true,  "72", "* %attack% -1", "* %attack% -1", "* %attack% -2"]
             ]
         },
-        { name: "Savvas Icestorm"
+        { class: "Savvas Icestorm"
         , cards:
             [ [false, "70", "* %push% 2", "** Target all adjacent enemies", "** %air%%use_element%: %push% 4 instead", "* %attack% +1", "** %range% +1"]
             , [false, "98", "* Summon normal Wind Demon", "* %air%"]
@@ -302,7 +302,7 @@ DECK_DEFINITONS =
             , [true,  "35", "* %move% -1", "* %attack% -1 %aoe-triangle-3-side-with-corner-black% ", "* %ice%"]
             ]
         },
-        { name: "Savvas Lavaflow"
+        { class: "Savvas Lavaflow"
         , cards:
             [ [false, "97", "* Summon normal Flame Demon", "* %fire%"]
             , [false, "97", "* Summon normal Earth Demon", "* %earth%"]
@@ -314,7 +314,7 @@ DECK_DEFINITONS =
             , [true,  "68", "* %move% -1", "* %attack% -1", "** %range% 3", "** %target% 2", "* %fire%"]
             ]
         },
-        { name: "Scout"
+        { class: "Scout"
         , cards:
             [ [false, "29", "* %move% -1", "* %attack% -1", "** %range% 3"]
             , [false, "40", "* %move% +1", "* %attack% -1"]
@@ -326,7 +326,7 @@ DECK_DEFINITONS =
             , [false, "79",  "* %attack% -1", "** %range% 4", "** %target% 2"]
             ]
         },
-        { name: "Shaman"
+        { class: "Shaman"
         , cards:
             [ [false, "08", "* %move% +0", "* %attack% -1", "** %disarm%"]
             , [false, "08", "* %move% -1", "* %attack% +0", "** %immobilize%"]
@@ -338,7 +338,7 @@ DECK_DEFINITONS =
             , [false, "09", "* %move% +1", "* %attack% -1", "** %curse%", "** %target% 2"]
             ]
         },
-        { name: "Spitting Drake"
+        { class: "Spitting Drake"
         , cards:
             [ [false, "32", "* %move% +1", "* %attack% -1"]
             , [false, "52", "* %move% +0", "* %attack% +0"]
@@ -350,7 +350,7 @@ DECK_DEFINITONS =
             , [true,  "89", "* %move% -1", "* %attack% -2 %aoe-circle%", "** %poison%"]
             ]
         },
-        { name: "Stone Golem"
+        { class: "Stone Golem"
         , cards:
             [ [false, "11", "* %retaliate% 3", "** %range% 3"]
             , [false, "28", "* %move% +1", "* %attack% +0", "* Stone Golem suffers 1 damage."]
@@ -362,7 +362,7 @@ DECK_DEFINITONS =
             , [false, "83", "* %move% +0", "* %attack% -1", "** Target all adjacent enemies"]
             ]
         },
-        { name: "Sun Demon"
+        { class: "Sun Demon"
         , cards:
             [ [true,  "17", "* %heal% 3", "** %range% 3", "** %light%%use_element%: Target all allies within range"]
             , [false, "36", "* %move% +0", "* %attack% +0", "** Target all adjacent enemies", "* %light%"]
@@ -374,7 +374,7 @@ DECK_DEFINITONS =
             , [false, "50", "* %move% +0", "* %attack% +0", "** %range% 3", "* %any%%use_element%: %light%"]
             ]
         },
-        { name: "Wind Demon"
+        { class: "Wind Demon"
         , cards:
             [ [false, "09", "* %attack% -1", "* %heal% 1", "** Self", "* %air%%use_element%: %invisible%<br/><span class='small'>Self</span>"]
             , [true,  "21", "* %move% +0", "* %attack% +0", "** %pull% 1", "* %air%"]

--- a/cards.js
+++ b/cards.js
@@ -1,5 +1,43 @@
-DECK_DEFINITONS =
-    [
+AVAILABLE_DECKS = 
+    [   {name: "Ancient Artillery", deck_name: "Ancient Artillery"}
+    ,   {name: "Bandit Archer", deck_name: "Archer"}
+    ,   {name: "City Archer", deck_name: "Archer"}
+    ,   {name: "Inox Archer", deck_name: "Archer"}
+    ,   {name: "Boss", deck_name: "Boss"}
+    ,   {name: "Cave Bear", deck_name: "Cave Bear"}
+    ,   {name: "Cultist", deck_name: "Cultist"}
+    ,   {name: "Deep Terror", deck_name: "Deep Terror"}
+    ,   {name: "Earth Demon", deck_name: "Earth Demon"}
+    ,   {name: "Flame Demon", deck_name: "Flame Demon"}
+    ,   {name: "Frost Demon", deck_name: "Frost Demon"}
+    ,   {name: "Giant Viperr", deck_name: "Giant Viper"}
+    ,   {name: "Bandit Guard", deck_name: "Guard"}
+    ,   {name: "City Guard", deck_name: "Guard"}
+    ,   {name: "Inox Guard", deck_name: "Guard"}
+    ,   {name: "Harrower Infester", deck_name: "Harrower Infester"}
+    ,   {name: "Hound", deck_name: "Hound"}
+    ,   {name: "Black Imp", deck_name: "Imp"}
+    ,   {name: "Forest Imp", deck_name: "Imp"}
+    ,   {name: "Living Bones", deck_name: "Living Bones"}
+    ,   {name: "Living Corpse", deck_name: "Living Corpse"}
+    ,   {name: "Lurker", deck_name: "Lurker"}
+    ,   {name: "Night Demon", deck_name: "Night Demon"}
+    ,   {name: "Ooze", deck_name: "Ooze"}
+    ,   {name: "Rending Drake", deck_name: "Rending Drake"}
+    ,   {name: "Savvas Icestorm", deck_name: "Savvas Icestorm"}
+    ,   {name: "Savvas Lavaflow", deck_name: "Savvas Lavaflow"}
+    ,   {name: "Inox Scout", deck_name: "Scout"}
+    ,   {name: "Vermling Scout", deck_name: "Scout"}
+    ,   {name: "Inox Shaman", deck_name: "Shaman"}
+    ,   {name: "Vermling Shaman", deck_name: "Shaman"}
+    ,   {name: "Spitting Drake", deck_name: "Spitting Drake"}
+    ,   {name: "Stone Golem", deck_name: "Stone Golem"}
+    ,   {name: "Sun Demon", deck_name: "Sun Demon"}
+    ,   {name: "Wind Demon", deck_name: "Wind Demon"}    
+];
+
+DECK_DEFINITONS = 
+[       
         { name: "Ancient Artillery"
         , cards:
             [ [false, "46", "* %attack% -1", "** %range% +2"]
@@ -342,10 +380,10 @@ DECK_DEFINITONS =
             , [true,  "21", "* %move% +0", "* %attack% +0", "** %pull% 1", "* %air%"]
             , [true,  "21", "* %move% +0", "* %attack% +0", "** %pull% 1", "* %air%"]
             , [false, "29", "* %move% +0", "* %attack% -1", "** %target% 2", "** %air%%use_element%: %push% 2"]
-            , [false, "37", "* %move% +0", "* %attack% +0 <div style='display: inline-block; width: 0; margin-top: -1.5em; vertical-align: bottom'>%aoe-4-with-black%</div>", "** %air%%use_element%: +1 %attack% <div style='display: inline-block; margin-right: -3em'>%aoe-circle-with-side-black%</div>"]
+            , [false, "37", "* %move% +0", "* %attack% +0 <div style='display: inline-block; width: 0; margin-top: -1.5em; vertical-align: bottom'>%aoe-4-with-black%</div>", "** %air%%use_element%: %attack% +1 <div style='display: inline-block; margin-right: -3em'>%aoe-circle-with-side-black%</div>"]
             , [false, "43", "* %move% -1", "* %attack% +1", "** %air%%use_element%: %target% 2"]
             , [false, "43", "* %push% 1", "** Target all adjacent enemies", "* %attack% +0", "** %earth%%use_element%: -2 %range%"]
             , [false, "02", "* %shield% 1", "* %move% -1", "* %attack% -1", "* %any%%use_element%: %air%"]
             ]
         }
-    ];
+];

--- a/cards.js
+++ b/cards.js
@@ -58,7 +58,7 @@ DECK_DEFINITONS =
             , [false, "44", "* %move% -1", "* %attack% +1"]
             , [false, "56", "* %attack% -1", "** %target% 2"]
             , [true,  "68", "* %attack% +1", "** %range% +1"]
-            , [false, "14", "* %move% -1", "* %attack% -1", "* Create a 3 damage trap in an adjacent empty hex closest to an enemy"]
+            , [false, "14", "* %move% -1", "* %attack% -1", "* <span class='small'> Create a 3 damage trap in an adjacent empty hex closest to an enemy </span>"]
             , [true,  "29", "* %move% +0", "* %attack% -1", "** %range% +1", "** %immobilize%"]
             ]
         },
@@ -127,7 +127,7 @@ DECK_DEFINITONS =
             [ [false, "03", "* %move% +1", "* %attack% -1", "* %fire%"]
             , [false, "24", "* %move% +0", "* %attack% +0", "* %fire%"]
             , [true,  "46", "* %attack% +0", "** %fire%%use_element%:  %aoe-circle%"]
-            , [false, "49", "* %attack% +0 %aoe-line-3-with-black%", "** %fire%%use_element%: +1 %attack%<br/>%wound%"]
+            , [false, "49", "* %attack% +0 %aoe-line-3-with-black%", "** %fire%%use_element%: +1 %attack%", "** %wound%"]
             , [false, "67", "* %move% -1", "* %attack% +1", "** %range% -1", "* %fire%"]
             , [false, "77", "* %attack% +0", "** Target all adjacent enemies", "** %ice%%use_element%:Flame Demon suffers 1 damage."]
             , [true,  "30", "* %fire%%use_element%: <span class='small'>All adjacent enemies suffer 2 damage.</span>", "* %move% +0", "* %attack% -2", "** %wound%", "** %target% 2"]
@@ -148,8 +148,8 @@ DECK_DEFINITONS =
         },
         { class: "Giant Viper"
         , cards:
-            [ [true,  "32", "* %move% +0", "* %attack% +0", "** Add +2 %attack% if the target is adjacent to any of the Giant Viper's allies."]
-            , [true,  "32", "* %move% +0", "* %attack% +0", "** Add +2 %attack% if the target is adjacent to any of the Giant Viper's allies."]
+            [ [true,  "32", "* %move% +0", "* %attack% +0", "** Add +2 Attack if the target is adjacent to any of the Giant Viper's allies."]
+            , [true,  "32", "* %move% +0", "* %attack% +0", "** Add +2 Attack if the target is adjacent to any of the Giant Viper's allies."]
             , [false, "11", "* %shield% 1", "* %attack% -1"]
             , [false, "43", "* %move% +1", "** %jump%", "* %attack% -1", "** Target all adjacent enemies."]
             , [false, "58", "* %move% -1", "* %attack% +1"]
@@ -177,7 +177,7 @@ DECK_DEFINITONS =
             , [false, "16", "* %move% -1", "* %attack% -1", "* %heal% 5", "** Self"]
             , [false, "16", "* %attack% +2", "** %immobilize%", "* %retaliate% 2"]
             , [true,  "02", "* %shield% 2", "* %retaliate% 2", "** %range% 3"]
-            , [false, "30", "* %move% -1", "* %attack% +0 %aoe-line-4-with-black%", "** %dark%%use_element%: Perform \"%heal% 2, Self\" for each target damaged"]
+            , [false, "30", "* %move% -1", "* %attack% +0 %aoe-line-4-with-black%", "** %dark%%use_element%: Perform \"%heal% 2, Self\" </br>for each target damaged"]
             , [false, "38", "* %move% +0", "* %attack% -1", "** %target% 2", "** %dark%%use_element%: +2 %attack%, %disarm%"]
             , [true,  "07", "* %attack% -1", "** %range% 3", "** %muddle%", "* %heal% 4", "** Self"]
             ]
@@ -186,8 +186,8 @@ DECK_DEFINITONS =
         , cards:
             [ [false, "06", "* %move% -1", "* %attack% +0", "** %immobilize%"]
             , [false, "07", "* %move% +0", "* %muddle%", "** Target all adjacent enemies"]
-            , [true,  "19", "* %move% +1", "* %attack% +0", "*** Add +2 %attack% if the target is adjacent to any of the Hound's allies"]
-            , [true,  "19", "* %move% +1", "* %attack% +0", "*** Add +2 %attack% if the target is adjacent to any of the Hound's allies"]
+            , [true,  "19", "* %move% +1", "* %attack% +0", "** Add +2 Attack if the target is adjacent to any of the Hound's allies"]
+            , [true,  "19", "* %move% +1", "* %attack% +0", "** Add +2 Attack if the target is adjacent to any of the Hound's allies"]
             , [false, "26", "* %move% +0", "* %attack% +0"]
             , [false, "26", "* %move% +0", "* %attack% +0"]
             , [false, "83", "* %move% -2", "* %attack% +1"]
@@ -263,7 +263,7 @@ DECK_DEFINITONS =
             , [true,  "46", "* %move% -1", "* %attack% +1", "** %dark%%use_element%: +2 %attack%"]
             , [true,  "41", "* %move% -1", "* %attack% +1", "* %dark%"]
             , [false, "35", "* %attack% -1", "* %attack% -1", "** %pierce% 2", "* %light%%use_element%: %curse%", "** Self"]
-            , [false, "15", "* %move% +0", "* %attack% -1", "* All adjacent enemies and allies suffer 1 damage.", "* %any%%use_element%: %dark%"]
+            , [false, "15", "* %move% +0", "* %attack% -1", "* <span class='small'>All adjacent enemies and allies suffer 1 damage.</span>", "* <span class='small'>%any%%use_element%: %dark%</span>"]
             ]
         },
         { class: "Ooze"
@@ -272,8 +272,8 @@ DECK_DEFINITONS =
             , [false, "57", "* %move% +0", "* %attack% +0"]
             , [false, "59", "* %attack% +0", "** %target% 2", "** %poison%"]
             , [false, "66", "* %move% -1", "* %attack% +1", "** %range% +1"]
-            , [true,  "94", "* Ooze suffers 2 damage ", "** Summons normal Ooze with a hit point value equal to the summoning Ooze's current hit point value (limited by a normal Ooze's specified maximum hit point value)"]
-            , [true,  "94", "* Ooze suffers 2 damage ", "** Summons normal Ooze with a hit point value equal to the summoning Ooze's current hit point value (limited by a normal Ooze's specified maximum hit point value)"]
+            , [true,  "94", "* Ooze suffers 2 damage ", "** <span class='small'>Summons normal Ooze with a hit point value equal to the summoning Ooze's current hit point value (limited by a normal Ooze's specified maximum hit point value)</span>"]
+            , [true,  "94", "* Ooze suffers 2 damage ", "** <span class='small'>Summons normal Ooze with a hit point value equal to the summoning Ooze's current hit point value (limited by a normal Ooze's specified maximum hit point value)</span>"]
             , [false, "85", "* %push% 1 and", "* %poison%", "** Target all adjacent enemies", "* %attack% +1", "** %range% -1"]
             , [false, "66", "* %move% -1", "* %loot% 1", "* %heal% 2", "** Self"]
             ]

--- a/cards.js
+++ b/cards.js
@@ -1,23 +1,24 @@
 DECKS =
     {   "Ancient Artillery":  {name: "Ancient Artillery", class: "Ancient Artillery"}
     ,   "Bandit Archer":      {name: "Bandit Archer", class: "Archer"}
-    ,   "City Archer":        {name: "City Archer", class: "Archer"}
-    ,   "Inox Archer":        {name: "Inox Archer", class: "Archer"}
+    ,   "Bandit Guard":       {name: "Bandit Guard", class: "Guard"}
+    ,   "Black Imp":          {name: "Black Imp", class: "Imp"}
     ,   "Boss":               {name: "Boss", class: "Boss"}
     ,   "Cave Bear":          {name: "Cave Bear", class: "Cave Bear"}
+    ,   "City Archer":        {name: "City Archer", class: "Archer"}
+    ,   "City Guard":         {name: "City Guard", class: "Guard"}
     ,   "Cultist":            {name: "Cultist", class: "Cultist"}
     ,   "Deep Terror":        {name: "Deep Terror", class: "Deep Terror"}
     ,   "Earth Demon":        {name: "Earth Demon", class: "Earth Demon"}
     ,   "Flame Demon":        {name: "Flame Demon", class: "Flame Demon"}
+    ,   "Forest Imp":         {name: "Forest Imp", class: "Imp"}
     ,   "Frost Demon":        {name: "Frost Demon", class: "Frost Demon"}
     ,   "Giant Viper":        {name: "Giant Viper", class: "Giant Viper"}
-    ,   "Bandit Guard":       {name: "Bandit Guard", class: "Guard"}
-    ,   "City Guard":         {name: "City Guard", class: "Guard"}
-    ,   "Inox Guard":         {name: "Inox Guard", class: "Guard"}
     ,   "Harrower Infester":  {name: "Harrower Infester", class: "Harrower Infester"}
     ,   "Hound":              {name: "Hound", class: "Hound"}
-    ,   "Black Imp":          {name: "Black Imp", class: "Imp"}
-    ,   "Forest Imp":         {name: "Forest Imp", class: "Imp"}
+    ,   "Inox Archer":        {name: "Inox Archer", class: "Archer"}
+    ,   "Inox Guard":         {name: "Inox Guard", class: "Guard"}
+    ,   "Inox Shaman":        {name: "Inox Shaman", class: "Shaman"}
     ,   "Living Bones":       {name: "Living Bones", class: "Living Bones"}
     ,   "Living Corpse":      {name: "Living Corpse", class: "Living Corpse"}
     ,   "Living Spirit":      {name: "Living Spirit", class: "Living Spirit"}
@@ -27,12 +28,11 @@ DECKS =
     ,   "Rending Drake":      {name: "Rending Drake", class: "Rending Drake"}
     ,   "Savvas Icestorm":    {name: "Savvas Icestorm", class: "Savvas Icestorm"}
     ,   "Savvas Lavaflow":    {name: "Savvas Lavaflow", class: "Savvas Lavaflow"}
-    ,   "Vermling Scout":   {name: "Vermling Scout", class: "Scout"}
-    ,   "Inox Shaman":        {name: "Inox Shaman", class: "Shaman"}
-    ,   "Vermling Shaman":    {name: "Vermling Shaman", class: "Shaman"}
     ,   "Spitting Drake":     {name: "Spitting Drake", class: "Spitting Drake"}
     ,   "Stone Golem":        {name: "Stone Golem", class: "Stone Golem"}
     ,   "Sun Demon":          {name: "Sun Demon", class: "Sun Demon"}
+    ,   "Vermling Scout":   {name: "Vermling Scout", class: "Scout"}
+    ,   "Vermling Shaman":    {name: "Vermling Shaman", class: "Shaman"}
     ,   "Wind Demon":         {name: "Wind Demon", class: "Wind Demon"}
 };
 

--- a/images/elderDrake.special1Area.svg
+++ b/images/elderDrake.special1Area.svg
@@ -1,0 +1,426 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="349.07388mm"
+   height="327.2269mm"
+   viewBox="0 0 349.07388 327.2269"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="elderDrake.special1Area.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="659.0272"
+     inkscape:cy="661.38497"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g4737"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1537"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(54.11373,-92.616752)">
+    <g
+       id="g4737"
+       transform="matrix(0.26458333,0,0,0.26458333,-32.737811,152.33149)">
+      <g
+         id="g4542-3"
+         transform="matrix(1.333333,0,0,-1.333333,50.000023,449.99972)">
+        <g
+           id="g4544-0"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4546-9"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4745">
+          <g
+             id="g4548-0">
+            <g
+               clip-path="url(#clipPath4554)"
+               id="g4550-4">
+              <g
+                 transform="translate(270.4375,80.4648)"
+                 id="g4556-2">
+                <path
+                   inkscape:connector-curvature="0"
+                   id="path4558-1"
+                   style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                   d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(245.6172,94.7949)"
+             id="g4560-1">
+            <path
+               inkscape:connector-curvature="0"
+               id="path4562-3"
+               style="fill:#535456;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               d="M 0,0 -95.617,-55.204 -191.234,0 V 110.41 L -95.617,165.615 0,110.41 Z" />
+          </g>
+        </g>
+        <g
+           transform="translate(123.438,213.104)"
+           id="g4745-7">
+          <g
+             id="g4548-0-8">
+            <g
+               clip-path="url(#clipPath4554)"
+               id="g4550-4-7">
+              <g
+                 transform="translate(270.4375,80.4648)"
+                 id="g4556-2-5">
+                <path
+                   inkscape:connector-curvature="0"
+                   id="path4558-1-3"
+                   style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                   d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(245.6172,94.7949)"
+             id="g4560-1-9">
+            <path
+               inkscape:connector-curvature="0"
+               id="path4562-3-4"
+               style="fill:#535456;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               d="M 0,0 -95.617,-55.204 -191.234,0 V 110.41 L -95.617,165.615 0,110.41 Z" />
+          </g>
+        </g>
+        <g
+           transform="translate(-123.6557,213.07857)"
+           id="g4745-78">
+          <g
+             id="g4548-0-83">
+            <g
+               clip-path="url(#clipPath4554)"
+               id="g4550-4-0">
+              <g
+                 transform="translate(270.4375,80.4648)"
+                 id="g4556-2-9">
+                <path
+                   inkscape:connector-curvature="0"
+                   id="path4558-1-7"
+                   style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                   d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(245.6172,94.7949)"
+             id="g4560-1-5">
+            <path
+               inkscape:connector-curvature="0"
+               id="path4562-3-1"
+               style="fill:#535456;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               d="M 0,0 -95.617,-55.204 -191.234,0 V 110.41 L -95.617,165.615 0,110.41 Z" />
+          </g>
+        </g>
+      </g>
+      <g
+         id="g4493-6"
+         transform="matrix(1.333333,0,0,-1.333333,380.87634,450.03363)">
+        <g
+           id="g4495-4"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4">
+          <g
+             id="g4501-5"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1"
+         transform="matrix(1.333333,0,0,-1.333333,711.75269,449.23727)">
+        <g
+           id="g-2-9"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5">
+          <g
+             id="g-4-0"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-9"
+         transform="matrix(1.333333,0,0,-1.333333,541.75057,165.86112)">
+        <g
+           id="g4495-4-6"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-3"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-1">
+          <g
+             id="g4501-5-2"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-7"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-4"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-9"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-3"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-7"
+         transform="matrix(1.333333,0,0,-1.333333,872.62692,165.06472)">
+        <g
+           id="g-2-9-9"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-6"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-3">
+          <g
+             id="g-4-0-7"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-7"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-8"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-8"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-0"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-5"
+         transform="matrix(1.333333,0,0,-1.333333,216.29371,736.17223)">
+        <g
+           id="g4495-4-3"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-4"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-0">
+          <g
+             id="g4501-5-6"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-2"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-2"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-7"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-7"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-3"
+         transform="matrix(1.333333,0,0,-1.333333,547.17005,735.37583)">
+        <g
+           id="g-2-9-4"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-8"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-1">
+          <g
+             id="g-4-0-8"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-3"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-3"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-4"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-8"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-3-7"
+         transform="matrix(1.333333,0,0,-1.333333,382.87767,1020.3108)">
+        <g
+           id="g-2-9-4-2"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-8-4"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-1-7">
+          <g
+             id="g-4-0-8-5"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-3-6"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-3-1"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-4-1"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-8-1"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/images/inoxBodyguard.special1Area.svg
+++ b/images/inoxBodyguard.special1Area.svg
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="261.90472mm"
+   height="251.83788mm"
+   viewBox="0 0 261.90472 251.83788"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="inoxBodyguard.special1Area.svg"
+   inkscape:version="0.92.1 r15371">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="329.56902"
+     inkscape:cy="376.45006"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g4542-3"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1537"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-33.055413,-92.616752)">
+    <g
+       id="g4737"
+       transform="matrix(0.26458333,0,0,0.26458333,-32.737811,152.33149)">
+      <g
+         id="g4542-3"
+         transform="matrix(1.333333,0,0,-1.333333,50.000023,449.99972)">
+        <g
+           transform="translate(123.438,213.104)"
+           id="g4745-7">
+          <g
+             id="g4548-0-8">
+            <g
+               clip-path="url(#clipPath4554)"
+               id="g4550-4-7">
+              <g
+                 transform="translate(270.4375,80.4648)"
+                 id="g4556-2-5">
+                <path
+                   inkscape:connector-curvature="0"
+                   id="path4558-1-3"
+                   style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                   d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(245.6172,94.7949)"
+             id="g4560-1-9">
+            <path
+               inkscape:connector-curvature="0"
+               id="path4562-3-4"
+               style="fill:#535456;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               d="M 0,0 -95.617,-55.204 -191.234,0 V 110.41 L -95.617,165.615 0,110.41 Z" />
+          </g>
+        </g>
+      </g>
+      <g
+         id="g4493-6"
+         transform="matrix(1.333333,0,0,-1.333333,380.87634,450.03363)">
+        <g
+           id="g4495-4"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4">
+          <g
+             id="g4501-5"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1"
+         transform="matrix(1.333333,0,0,-1.333333,711.75269,449.23727)">
+        <g
+           id="g-2-9"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5">
+          <g
+             id="g-4-0"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-9"
+         transform="matrix(1.333333,0,0,-1.333333,541.75057,165.86112)">
+        <g
+           id="g4495-4-6"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-3"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-1">
+          <g
+             id="g4501-5-2"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-7"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-4"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-9"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-3"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-7"
+         transform="matrix(1.333333,0,0,-1.333333,872.62692,165.06472)">
+        <g
+           id="g-2-9-9"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-6"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-3">
+          <g
+             id="g-4-0-7"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-7"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-8"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-8"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-0"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-3"
+         transform="matrix(1.333333,0,0,-1.333333,547.17005,735.37583)">
+        <g
+           id="g-2-9-4"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-8"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-1">
+          <g
+             id="g-4-0-8"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-3"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-3"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-4"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-8"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/images/sightlessEye.special1Area.svg
+++ b/images/sightlessEye.special1Area.svg
@@ -1,0 +1,664 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="479.18253mm"
+   height="327.75607mm"
+   viewBox="0 0 479.18252 327.75607"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="sightlessEye.special1Area.svg"
+   inkscape:version="0.92.1 r15371">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="821.31822"
+     inkscape:cy="620.88673"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g4737"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1537"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(184.22237,-92.616752)">
+    <g
+       id="g4737"
+       transform="matrix(0.26458333,0,0,0.26458333,-32.737811,152.33149)">
+      <g
+         id="g4542-3"
+         transform="matrix(1.333333,0,0,-1.333333,50.000023,449.99972)">
+        <g
+           transform="translate(-123.6557,213.07857)"
+           id="g4745-78">
+          <g
+             id="g4548-0-83">
+            <g
+               clip-path="url(#clipPath4554)"
+               id="g4550-4-0">
+              <g
+                 transform="translate(270.4375,80.4648)"
+                 id="g4556-2-9">
+                <path
+                   inkscape:connector-curvature="0"
+                   id="path4558-1-7"
+                   style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                   d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(245.6172,94.7949)"
+             id="g4560-1-5">
+            <path
+               inkscape:connector-curvature="0"
+               id="path4562-3-1"
+               style="fill:#535456;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               d="M 0,0 -95.617,-55.204 -191.234,0 V 110.41 L -95.617,165.615 0,110.41 Z" />
+          </g>
+        </g>
+      </g>
+      <g
+         id="g4493-6"
+         transform="matrix(1.333333,0,0,-1.333333,380.87634,450.03363)">
+        <g
+           id="g4495-4"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4">
+          <g
+             id="g4501-5"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1"
+         transform="matrix(1.333333,0,0,-1.333333,711.75269,449.23727)">
+        <g
+           id="g-2-9"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5">
+          <g
+             id="g-4-0"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-9"
+         transform="matrix(1.333333,0,0,-1.333333,541.75057,165.86112)">
+        <g
+           id="g4495-4-6"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-3"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-1">
+          <g
+             id="g4501-5-2"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-7"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-4"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-9"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-3"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-7"
+         transform="matrix(1.333333,0,0,-1.333333,872.62692,165.06472)">
+        <g
+           id="g-2-9-9"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-6"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-3">
+          <g
+             id="g-4-0-7"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-7"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-8"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-8"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-0"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-3-7"
+         transform="matrix(1.333333,0,0,-1.333333,-277.45683,450.03363)">
+        <g
+           id="g-2-9-4-2"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-8-4"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-1-7">
+          <g
+             id="g-4-0-8-5"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-3-6"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-3-1"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-4-1"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-8-1"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-9-3"
+         transform="matrix(1.333333,0,0,-1.333333,214.29238,165.89503)">
+        <g
+           id="g4495-4-6-7"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-3-7"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-1-7">
+          <g
+             id="g4501-5-2-1"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-7-8"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-4-9"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-9-0"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-3-2"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-9-8"
+         transform="matrix(1.333333,0,0,-1.333333,51.709757,450.03363)">
+        <g
+           id="g4495-4-6-4"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-3-4"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-1-9">
+          <g
+             id="g4501-5-2-5"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-7-4"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-4-8"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-9-03"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-3-9"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-8"
+         transform="matrix(1.333333,0,0,-1.333333,216.29238,736.17223)">
+        <g
+           id="g4495-4-0"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-1"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-9">
+          <g
+             id="g4501-5-21"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-0"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-1"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-8"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-6"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-2"
+         transform="matrix(1.333333,0,0,-1.333333,547.16879,735.37587)">
+        <g
+           id="g-2-9-6"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-8"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-8">
+          <g
+             id="g-4-0-1"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-1"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-5"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-83"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-3"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-3-7-2"
+         transform="matrix(1.333333,0,0,-1.333333,-442.04079,736.17223)">
+        <g
+           id="g-2-9-4-2-4"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-8-4-0"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-1-7-0">
+          <g
+             id="g-4-0-8-5-2"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-3-6-4"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-3-1-2"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-4-1-5"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-8-1-6"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-9-8-0"
+         transform="matrix(1.333333,0,0,-1.333333,-112.8742,736.17223)">
+        <g
+           id="g4495-4-6-4-3"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-3-4-7"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-1-9-7">
+          <g
+             id="g4501-5-2-5-6"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-7-4-4"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-4-8-1"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-9-03-8"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-3-9-2"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-0"
+         transform="matrix(1.333333,0,0,-1.333333,51.70976,1022.3108)">
+        <g
+           id="g4495-4-1"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-5"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-10">
+          <g
+             id="g4501-5-7"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-00"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-12"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-0"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-7"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-8"
+         transform="matrix(1.333333,0,0,-1.333333,382.58612,1021.5145)">
+        <g
+           id="g-2-9-8"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-80"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-1">
+          <g
+             id="g-4-0-6"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-4"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-4"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-3"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-8"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-3-7-7"
+         transform="matrix(1.333333,0,0,-1.333333,-606.62341,1022.3108)">
+        <g
+           id="g-2-9-4-2-1"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-8-4-2"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-1-7-1">
+          <g
+             id="g-4-0-8-5-8"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-3-6-6"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-3-1-0"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-4-1-6"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-8-1-2"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-9-8-4"
+         transform="matrix(1.333333,0,0,-1.333333,-277.45682,1022.3108)">
+        <g
+           id="g4495-4-6-4-7"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-3-4-5"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-1-9-5">
+          <g
+             id="g4501-5-2-5-1"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-7-4-7"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-4-8-3"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-9-03-3"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-3-9-9"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/images/sightlessEye.special2Area.svg
+++ b/images/sightlessEye.special2Area.svg
@@ -1,0 +1,436 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="349.07388mm"
+   height="327.2269mm"
+   viewBox="0 0 349.07388 327.2269"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="sightlessEye.special2Area.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="494.87741"
+     inkscape:cy="661.38497"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g4737"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1537"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(54.11373,-92.616752)">
+    <g
+       id="g4737"
+       transform="matrix(0.26458333,0,0,0.26458333,-32.737811,152.33149)">
+      <g
+         id="g4542-3"
+         transform="matrix(1.333333,0,0,-1.333333,50.000023,449.99972)">
+        <g
+           transform="translate(-123.6557,213.07857)"
+           id="g4745-78">
+          <g
+             id="g4548-0-83">
+            <g
+               clip-path="url(#clipPath4554)"
+               id="g4550-4-0">
+              <g
+                 transform="translate(270.4375,80.4648)"
+                 id="g4556-2-9">
+                <path
+                   inkscape:connector-curvature="0"
+                   id="path4558-1-7"
+                   style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                   d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="translate(245.6172,94.7949)"
+             id="g4560-1-5">
+            <path
+               inkscape:connector-curvature="0"
+               id="path4562-3-1"
+               style="fill:#535456;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               d="M 0,0 -95.617,-55.204 -191.234,0 V 110.41 L -95.617,165.615 0,110.41 Z" />
+          </g>
+        </g>
+      </g>
+      <g
+         id="g4493-6"
+         transform="matrix(1.333333,0,0,-1.333333,378.87634,450.03363)">
+        <g
+           id="g4495-4"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4">
+          <g
+             id="g4501-5"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1"
+         transform="matrix(1.333333,0,0,-1.333333,709.75269,449.23727)">
+        <g
+           id="g-2-9"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5">
+          <g
+             id="g-4-0"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-9"
+         transform="matrix(1.333333,0,0,-1.333333,543.75057,165.86112)">
+        <g
+           id="g4495-4-6"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-3"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-1">
+          <g
+             id="g4501-5-2"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-7"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-4"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-9"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-3"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-7"
+         transform="matrix(1.333333,0,0,-1.333333,872.62692,165.06472)">
+        <g
+           id="g-2-9-9"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-6"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-3">
+          <g
+             id="g-4-0-7"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-7"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-8"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-8"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-0"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-5"
+         transform="matrix(1.333333,0,0,-1.333333,216.29371,736.17223)">
+        <g
+           id="g4495-4-3"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-4"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-0">
+          <g
+             id="g4501-5-6"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-2"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-2"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-7"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-7"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-3"
+         transform="matrix(1.333333,0,0,-1.333333,547.17005,735.37583)">
+        <g
+           id="g-2-9-4"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-8"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-1">
+          <g
+             id="g-4-0-8"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-3"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-3"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-4"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-8"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g-1-1-3-7"
+         transform="matrix(1.333333,0,0,-1.333333,382.87767,1020.3108)">
+        <g
+           id="g-2-9-4-2"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-1-2-8-4"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g-3-5-1-7">
+          <g
+             id="g-4-0-8-5"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g-5-2-3-6"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path-2-8-3-1"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g-6-6-4-1"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path-3-2-8-1"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-9-7"
+         transform="matrix(1.333333,0,0,-1.333333,214.29238,165.89503)">
+        <g
+           id="g4495-4-6-2"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-3-8"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-1-3">
+          <g
+             id="g4501-5-2-9"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-7-9"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-4-1"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-9-0"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-3-7"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+      <g
+         id="g4493-6-9-7-9"
+         transform="matrix(1.333333,0,0,-1.333333,49.711083,452.03363)">
+        <g
+           id="g4495-4-6-2-9"
+           transform="translate(270.4375,80.4648)">
+          <path
+             d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+             style="fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4497-5-3-8-2"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4499-4-1-3-0">
+          <g
+             id="g4501-5-2-9-7"
+             clip-path="url(#clipPath4505)">
+            <g
+               id="g4507-9-7-9-4"
+               transform="translate(270.4375,80.4648)">
+              <path
+                 d="M 0,0 -120.438,-69.534 -240.875,0 V 139.07 L -120.438,208.604 0,139.07 Z"
+                 style="fill:none;stroke:#231f20;stroke-width:8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+                 id="path4509-5-4-1-4"
+                 inkscape:connector-curvature="0" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g4511-6-9-0-5"
+           transform="translate(245.6172,94.7949)">
+          <path
+             d="M 0,0 -95.617,-55.204 -191.235,0 V 110.41 L -95.617,165.615 0,110.41 Z"
+             style="fill:#c71e25;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             id="path4513-3-3-7-0"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <script type="text/javascript" src="scenarios.js"></script>
         <script type="text/javascript" src="macros.js"></script>
         <script type="text/javascript" src="modifiers.js"></script>
+        <script type="text/javascript" src="monster_stats.js"></script>
         <script type="text/javascript" src="logic.js"></script>
         <script type="text/javascript" src="ui.js"></script>
     </head>

--- a/logic.js
+++ b/logic.js
@@ -66,27 +66,27 @@ function UICard(front_element, back_element)
     return card;
 }
 
-function create_ability_card_back(name)
+function create_ability_card_back(name, level)
 {
     var card = document.createElement("div");
     card.className = "card ability back down";
 
     var name_span = document.createElement("span");
     name_span.className = "name";
-    name_span.innerText = name;
+    name_span.innerText = name + "-" + level;
     card.appendChild(name_span);
 
     return card;
 }
 
-function create_ability_card_front(initiative, name, shuffle, lines, attack, move, range)
+function create_ability_card_front(initiative, name, shuffle, lines, attack, move, range, level)
 {
     var card = document.createElement("div");
     card.className = "card ability front down";
 
     var name_span = document.createElement("span");
     name_span.className = "name";
-    name_span.innerText = name;
+    name_span.innerText = name + "-" + level;
     card.appendChild(name_span);
 
     var initiative_span = document.createElement("span");
@@ -178,7 +178,8 @@ function load_ability_deck(deck_definition)
         discard:                [],
         move:                   [0,0],
         attack:                 [0,0],
-        range:                  [0,0]
+        range:                  [0,0],
+        level:                  deck_definition.level
     }
 
     for (var i = 0; i < deck_definition.cards.length; i++)
@@ -192,31 +193,18 @@ function load_ability_deck(deck_definition)
         var empty_front = document.createElement("div");
         empty_front.className = "card ability front down";
         var card_front = empty_front;
-        var card_back = create_ability_card_back(deck.name);
+        var card_back = create_ability_card_back(deck.name, deck.level);
 
         var card = {
             ui:             new UICard(card_front, card_back),
             shuffle_next:   shuffle,
             initiative:     initiative,
             starting_lines: lines,
-            name:           deck.name,
-            shuffle:        shuffle
         };
 
-        card.change_displaying_name = function (new_name)
-            {
-                Array.prototype.forEach.call(this.ui.front.getElementsByClassName("name"), function(element) {
-                    element.innerText = new_name;
-                });
-                Array.prototype.forEach.call(this.ui.back.getElementsByClassName("name"), function(element) {
-                    element.innerText = new_name;
-                });
-                this.name = new_name;
-            }
-
-        card.paint_front_card = function (name, lines, attack, move, range)
+        card.paint_front_card = function (name, lines, attack, move, range, level)
         {
-            this.ui.front = create_ability_card_front(this.initiative, name, this.shuffle, lines, attack, move, range);
+            this.ui.front = create_ability_card_front(this.initiative, name, this.shuffle_next, lines, attack, move, range, level);
         }
 
         deck.draw_pile.push(card);
@@ -252,7 +240,7 @@ function load_ability_deck(deck_definition)
 
         }
 
-        this.draw_pile[0].paint_front_card(this.get_real_name(), cards_lines.concat(extra_lines), this.attack, this.move, this.range);
+        this.draw_pile[0].paint_front_card(this.get_real_name(), cards_lines.concat(extra_lines), this.attack, this.move, this.range, this.level);
         force_repaint_deck(this);
     }
 
@@ -273,10 +261,6 @@ function load_ability_deck(deck_definition)
     {
         // This will serve to know when we can load the monster data (Move/Attack)
         this.name = real_name;
-        this.draw_pile.concat(this.discard).forEach(
-            function(card) {
-                card.change_displaying_name(real_name);
-            });
     }
 
     deck.set_stats_monster = function(stats)
@@ -693,10 +677,11 @@ function load_definition(card_database)
     return decks;
 }
 
-function load_deck(deck_class, deck_name)
+function load_deck(deck_class, deck_name, level)
 {
     var definition = deck_definitions[deck_class];
     definition.name = deck_name;
+    definition.level = level;
     return load_ability_deck(definition);
 }
 
@@ -732,16 +717,18 @@ function get_boss_stats(name, level)
     return { "attack": attack, "move": move, "range": range, "special1": special1, "special2": special2, "immunities": immunities, "notes": notes}
 }
 
-function apply_deck_selection(decks, preserve_existing_deck_state, monster_level, special_rules)
+function apply_deck_selection(decks, preserve_existing_deck_state)
 {
     var container = document.getElementById("tableau");
 
     var decks_to_remove = visible_ability_decks.filter(function(visible_deck) {
-        return !preserve_existing_deck_state || (decks.filter(function(deck){return (deck.name == visible_deck.name)}).length == 0);
+        return !preserve_existing_deck_state || (decks.filter(function(deck){
+            return ((deck.name == visible_deck.name) && (deck.level == visible_deck.level))}).length == 0);
     });
 
     var decks_to_add = decks.filter(function(deck) {
-        return !preserve_existing_deck_state || (visible_ability_decks.filter(function(visible_deck){return (deck.name == visible_deck.name)}).length == 0);
+        return !preserve_existing_deck_state || (visible_ability_decks.filter(function(visible_deck){
+            return ((deck.name == visible_deck.name) && (deck.level == visible_deck.level))}).length == 0);
     });
 
     if (!modifier_deck)
@@ -784,18 +771,13 @@ function apply_deck_selection(decks, preserve_existing_deck_state, monster_level
             // We don't want stats if someone selects Boss on the deck tab
             if (deck.get_real_name() != "Boss")
             {
-                deck.set_stats_boss(get_boss_stats(deck.get_real_name(), monster_level));
+                deck.set_stats_boss(get_boss_stats(deck.get_real_name(), deck.level));
             }
-            force_repaint_deck(deck);
         } else {
-            var level = monster_level;
-            if ( (special_rules[0] == SPECIAL_RULES.living_corpse_two_levels_extra) && (deck.get_real_name() == SPECIAL_RULES.living_corpse_two_levels_extra.affected_deck))
-            {
-                level = Math.min(7, (parseInt(monster_level) + parseInt(SPECIAL_RULES.living_corpse_two_levels_extra.extra_levels)));
-            }
-            deck.set_stats_monster(get_monster_stats(deck.get_real_name(), level));
-            force_repaint_deck(deck);
+            deck.set_stats_monster(get_monster_stats(deck.get_real_name(), deck.level));
+            
         }
+        force_repaint_deck(deck);
 
         visible_ability_decks.push(deck);
     });
@@ -893,27 +875,32 @@ function add_modifier_deck(container, deck)
 
 }
 
-function LevelSelector()
+function LevelSelector(text, inline)
 {
     var max_level = 7;
     var level = {};
-    level.ul = document.createElement("ul");
-    level.ul.className = "selectionlist";
+    level.html = inline ? document.createElement("span") : document.createElement("ul");
+    level.html.className = "selectionlist";
 
-    var listitem = document.createElement("li");
-    listitem.innerText = "Select level";
-    level.ul.appendChild(listitem);
+    var listitem = inline ? document.createElement("label") : document.createElement("li");
+    listitem.innerText = text;
+    level.html.appendChild(listitem);
 
     var level_spinner = create_input("number", "scenario_number", "1", "");
     level_spinner.input.min = 0;
     level_spinner.input.max = max_level;
-    level.ul.appendChild(level_spinner.input);
+    level.html.appendChild(level_spinner.input);
     level.spinner = level_spinner.input;
 
     level.get_selection = function()
     {
         var current_value = this.spinner.value;
         return (current_value > max_level) ? max_level : current_value;
+    }
+
+    level.set_value = function(value)
+    {
+        this.spinner.value = (value > max_level) ? max_level : value;
     }
 
     return level;
@@ -925,16 +912,22 @@ function DeckList()
     decklist.ul = document.createElement("ul");
     decklist.ul.className = "selectionlist";
     decklist.checkboxes = {};
+    decklist.level_selectors = {};
 
     for (key in DECKS)
     {
-      var real_name = DECKS[key].name;
-      var listitem = document.createElement("li");
-      var dom_dict = create_input("checkbox", "deck", real_name, real_name);
+        var real_name = DECKS[key].name;
+        var listitem = document.createElement("li");
+        var dom_dict = create_input("checkbox", "deck", real_name, real_name);
 
-      listitem.appendChild(dom_dict.root);
-      decklist.ul.appendChild(listitem);
-      decklist.checkboxes[real_name] = dom_dict.input;
+        listitem.appendChild(dom_dict.root);
+        var levelselector = new LevelSelector(" with level ", true);
+        listitem.appendChild(levelselector.html);
+
+        decklist.ul.appendChild(listitem);
+        decklist.checkboxes[real_name] = dom_dict.input;
+        decklist.level_selectors[real_name] = levelselector;
+        
     };
 
     decklist.get_selection = function()
@@ -946,22 +939,25 @@ function DeckList()
     {
         var selected_checkbox = this.get_selection();
         var selected_decks = concat_arrays(selected_checkbox.map( function(name) {
-            return ((name in DECKS) ? DECKS[name] : []);
+            var deck = ((name in DECKS) ? DECKS[name] : []);
+            deck.level = decklist.level_selectors[name].get_selection();
+            return deck;
         }.bind(this)));
         return selected_decks;
     }
 
-    decklist.set_selection = function(selected_decks)
+    decklist.set_selection = function(selected_deck_names)
     {
         dict_values(this.checkboxes).forEach( function(checkbox) {
             checkbox.checked = false;
         });
 
-        selected_decks.forEach(function(deck_name) {
-            var checkbox = this.checkboxes[deck_name];
+        selected_deck_names.forEach(function(deck_names) {
+            var checkbox = this.checkboxes[deck_names.name];
             if (checkbox)
             {
                 checkbox.checked = true;
+                decklist.level_selectors[deck_names.name].set_value(deck_names.level);
             }
         }.bind(this));
     }
@@ -977,6 +973,11 @@ function ScenarioList(scenarios)
     scenariolist.spinner = null;
     scenariolist.decks = {};
     scenariolist.special_rules = {};
+    scenariolist.level_selector = null;
+
+    scenariolist.level_selector = new LevelSelector("Select level", false);
+    
+    scenariolist.ul.appendChild(scenariolist.level_selector.html);
 
     for (var i = 0; i < scenarios.length; i++)
     {
@@ -1002,6 +1003,20 @@ function ScenarioList(scenarios)
         return Math.min(current_value, scenarios.length + 1);
     }
 
+    scenariolist.get_level = function(deck_name, special_rules)
+    {
+        
+        var base_level = scenariolist.level_selector.get_selection();
+
+        if ( (special_rules.indexOf(SPECIAL_RULES.living_corpse_two_levels_extra) >= 0) && (deck_name == SPECIAL_RULES.living_corpse_two_levels_extra.affected_deck))
+        {
+            return Math.min(7, (parseInt(base_level) + parseInt(SPECIAL_RULES.living_corpse_two_levels_extra.extra_levels)));
+        } else 
+        {
+            return base_level;
+        }
+    }
+
     scenariolist.get_scenario_decks = function()
     {
         return (this.decks[this.get_selection()].map(function(deck)
@@ -1013,6 +1028,9 @@ function ScenarioList(scenarios)
             {
                 deck.class = DECKS["Boss"].class;
             }
+
+            var special_rules = scenariolist.get_special_rules();
+            deck.level = scenariolist.get_level(deck.name, special_rules);
 
             return deck;
         }));
@@ -1035,32 +1053,29 @@ function init()
 
     var decklist = new DeckList();
     var scenariolist = new ScenarioList(SCENARIO_DEFINITIONS);
-    var levelselector = new LevelSelector();
 
     deckspage.insertAdjacentElement("afterbegin", decklist.ul);
-    deckspage.insertAdjacentElement("afterbegin", levelselector.ul);
     scenariospage.insertAdjacentElement("afterbegin", scenariolist.ul);
-    scenariospage.insertAdjacentElement("afterbegin", levelselector.ul);
 
     applydeckbtn.onclick = function()
     {
         var selected_deck_names = decklist.get_selected_decks();
         var selected_decks = selected_deck_names.map( function(deck_names)
                                                 {
-                                                    return load_deck(deck_names.class, deck_names.name);
+                                                    return load_deck(deck_names.class, deck_names.name, deck_names.level);
                                                 } );
-        apply_deck_selection(selected_decks, true, levelselector.get_selection(), special_rules = [""]);
+        apply_deck_selection(selected_decks, true);
     };
 
     applyscenariobtn.onclick = function()
     {
         var selected_deck_names = scenariolist.get_scenario_decks();
+        decklist.set_selection(selected_deck_names);
         var selected_decks = selected_deck_names.map( function(deck_names)
                                                 {
-                                                    return load_deck(deck_names.class, deck_names.name);
+                                                    return load_deck(deck_names.class, deck_names.name, deck_names.level);
                                                 } );
-        decklist.set_selection(selected_decks.map( function(deck) { return deck.get_real_name(); } ));
-        apply_deck_selection(selected_decks, false, levelselector.get_selection(), special_rules=scenariolist.get_special_rules());
+        apply_deck_selection(selected_decks, false);
     };
 
     window.onresize = refresh_ui.bind(null, visible_ability_decks);

--- a/logic.js
+++ b/logic.js
@@ -930,6 +930,25 @@ function DeckList()
     decklist.ul.className = "selectionlist";
     decklist.checkboxes = {};
     decklist.level_selectors = {};
+    decklist.global_level_selector = null;
+
+
+    var listitem = document.createElement("li");
+    var global_level_selector = new LevelSelector("Select global level ", true);
+    listitem.appendChild(global_level_selector.html);
+    decklist.global_level_selector = global_level_selector;
+    
+    var dom_dict = create_input("button", "applylevel", "Apply All", "");
+    dom_dict.input.onclick = function()
+    {
+        for (key in decklist.level_selectors)
+        {
+            decklist.level_selectors[key].set_value(decklist.global_level_selector.get_selection());
+        }
+    };
+    listitem.appendChild(dom_dict.root);
+
+    decklist.ul.appendChild(listitem);
 
     for (key in DECKS)
     {
@@ -938,12 +957,12 @@ function DeckList()
         var dom_dict = create_input("checkbox", "deck", real_name, real_name);
         listitem.appendChild(dom_dict.root);
         
-        var levelselector = new LevelSelector(" with level ", true);
-        listitem.appendChild(levelselector.html);
+        var level_selector = new LevelSelector(" with level ", true);
+        listitem.appendChild(level_selector.html);
 
         decklist.ul.appendChild(listitem);
         decklist.checkboxes[real_name] = dom_dict.input;
-        decklist.level_selectors[real_name] = levelselector;
+        decklist.level_selectors[real_name] = level_selector;
         
     };
 

--- a/logic.js
+++ b/logic.js
@@ -168,8 +168,12 @@ function create_ability_card_front(initiative, name, shuffle, lines, attack, mov
     return card;
 }
 
-function load_ability_deck(deck_definition)
+function load_ability_deck(deck_class, deck_name, level)
 {
+    var deck_definition = deck_definitions[deck_class];
+    deck_definition.name = deck_name;
+    deck_definition.level = level;
+
     var deck = {
         class:                  deck_definition.class,
         name:                   deck_definition.name,
@@ -256,12 +260,6 @@ function load_ability_deck(deck_definition)
       }
     }
 
-    deck.set_real_name = function(real_name)
-    {
-        // This will serve to know when we can load the monster data (Move/Attack)
-        this.name = real_name;
-    }
-
     deck.set_stats_monster = function(stats)
     {
         this.attack = stats.attack;
@@ -284,18 +282,6 @@ function load_ability_deck(deck_definition)
     deck.get_real_name = function()
     {
         return (this.name) ? this.name : this.class;
-    }
-
-    deck.clean_real_name = function()
-    {
-      if (this.name)
-      {
-        this.name = "";
-        this.draw_pile.concat(this.discard).forEach(
-            function(card) {
-                card.change_displaying_name(deck.class);
-            });
-      }
     }
 
     deck.is_boss = function()
@@ -694,15 +680,6 @@ function load_definition(card_database)
     return decks;
 }
 
-function load_deck(deck_class, deck_name, level)
-{
-    var definition = deck_definitions[deck_class];
-    definition.name = deck_name;
-    definition.level = level;
-
-    return load_ability_deck(definition);
-}
-
 function get_monster_stats(name, level)
 {
     var attack =        [   MONSTER_STATS["monsters"][name]["level"][level]["normal"]["attack"],
@@ -1095,7 +1072,7 @@ function init()
         var selected_deck_names = decklist.get_selected_decks();
         var selected_decks = selected_deck_names.map( function(deck_names)
                                                 {
-                                                    return load_deck(deck_names.class, deck_names.name, deck_names.level);
+                                                    return load_ability_deck(deck_names.class, deck_names.name, deck_names.level);
                                                 } );
         apply_deck_selection(selected_decks, true);
     };
@@ -1106,7 +1083,7 @@ function init()
         decklist.set_selection(selected_deck_names);
         var selected_decks = selected_deck_names.map( function(deck_names)
                                                 {
-                                                    return load_deck(deck_names.class, deck_names.name, deck_names.level);
+                                                    return load_ability_deck(deck_names.class, deck_names.name, deck_names.level);
                                                 } );
         apply_deck_selection(selected_decks, false);
     };

--- a/macros.js
+++ b/macros.js
@@ -1,4 +1,3 @@
-
 /* Macros used in card text, alphabetical order */
 MACROS =
     { "%air%":                                      "<img class='element' src='images/air.svg'>"
@@ -15,6 +14,10 @@ MACROS =
     , "%aoe-triangle-3-side-with-corner-black%":    "<div class='collapse'><img class='aoe h3' src='images/aoe-triangle-3-side-with-corner-black.svg'></div>"
     , "%attack%":                                   "<span class='nobr'>Attack <img class='icon' src='images/attack.svg'></span>"
     , "%bless%":                                    "<span class='nobr'>BLESS <img class='icon' src='images/bless.svg'></span>"
+    , "%boss-aoe-elder-drake-sp1%":                 "<div class='collapse'><img class='aoe h3' src='images/elderDrake.special1Area.svg'></div>"
+    , "%boss-aoe-inox-bodyguard-sp1%":              "<div class='collapse'><img class='aoe h3' src='images/inoxBodyguard.special1Area.svg'></div>"
+    , "%boss-aoe-sightless-eye-sp1%":               "<div class='collapse'><img class='aoe h3' src='images/sightlessEye.special1Area.svg'></div>"
+    , "%boss-aoe-sightless-eye-sp2%":               "<div class='collapse'><img class='aoe h3' src='images/sightlessEye.special2Area.svg'></div>"
     , "%curse%":                                    "<span class='nobr'>CURSE <img class='icon' src='images/curse.svg'></span>"
     , "%dark%":                                     "<img class='element' src='images/dark.svg'>"
     , "%disarm%":                                   "<span class='nobr'>DISARM <img class='icon' src='images/disarm.svg'></span>"
@@ -58,9 +61,9 @@ function expand_macro(macro)
 
 function expand_stat(s, stat, value)
 {
-    var re = new RegExp("%" + stat + "% (\\+|-)(\\d*)", "i");
+    var re = new RegExp("%" + stat + "% (\\+|-)(\\d*)(.*)\$", "i");
     var line_parsed = s.match(re);
-
+    
     var has_elite_value = (value.length == 2);
     var normal_attack = value[0];
     //Check in case of bosses with text in the attack
@@ -75,29 +78,30 @@ function expand_stat(s, stat, value)
     }
 
     if (line_parsed) {
-      if (line_parsed[1] == "+")
-      {
+        var rest_of_line = line_parsed[3] ? line_parsed[3] : "";
+        if (line_parsed[1] == "+")
+        {
             var value_normal = normal_attack + parseInt(line_parsed[2]);
             if (has_elite_value)
             {
                 var value_elite = value[1] + parseInt(line_parsed[2]);
-                return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>");
-            } else 
+                return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>" + rest_of_line);
+            } else
             {
-                 return ("%" + stat + "% " + extra_text_for_particular_bosses + value_normal);
+                 return ("%" + stat + "% " + extra_text_for_particular_bosses + value_normal + rest_of_line);
             }
-      } else if (line_parsed[1] == "-")
-      {
+        } else if (line_parsed[1] == "-")
+        {
             var value_normal = normal_attack - parseInt(line_parsed[2]);
             if (has_elite_value)
             {
                 var value_elite = value[1] - parseInt(line_parsed[2]);
-                return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>");
-            } else 
+                return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>" + rest_of_line);
+            } else
             {
-                 return ("%" + stat + "% " + extra_text_for_particular_bosses + value_normal );
+                 return ("%" + stat + "% " + extra_text_for_particular_bosses + value_normal + rest_of_line);
             }
-      }
+        }
     }
 
     return s;
@@ -124,7 +128,7 @@ function attributes_to_lines(attributes)
                 line++;
             }
         }
-        attributes_lines = attributes_lines.concat(normal_attributes_lines.map(function(line) { return line ? "** <span class='small'>" + line.replace(/(,\s$)/g, "") + "</span>" : "";}));
+        attributes_lines = attributes_lines.concat(normal_attributes_lines.map(function(line) { return line ? "**" + line.replace(/(,\s$)/g, "") : "";}));
 
         // Write elite only attributes in Gold
         var elite_attributes_lines = [""];
@@ -142,7 +146,7 @@ function attributes_to_lines(attributes)
                 line++;
             }
         }
-        attributes_lines = attributes_lines.concat(elite_attributes_lines.map(function(line) { return line ? "** <span class='small elite-color'>" + line.replace(/(,\s$)/g, "") + "</span>" : "";}));
+        attributes_lines = attributes_lines.concat(elite_attributes_lines.map(function(line) { return line ? "** <span class='elite-color'>" + line.replace(/(,\s$)/g, "") + "</span>" : "";}));
 
         return attributes_lines;
     }
@@ -204,4 +208,3 @@ function expand_string(s, attack, move, range)
     s = expand_stat(s, "range", range);
     return s.replace(/%[^%]*%/gi, expand_macro);
 }
-

--- a/macros.js
+++ b/macros.js
@@ -61,15 +61,15 @@ function expand_macro(macro)
 
 function expand_stat(s, stat, value)
 {
-    var re = new RegExp("%" + stat + "% (\\+|-)(\\d*)(.*)\$", "i");
-    var line_parsed = s.match(re);
+    var re = new RegExp("%" + stat + "% (\\+|-)(\\d*)", "g");
+    var line_parsed = re.exec(s);
     
     var has_elite_value = (value.length == 2);
     var normal_attack = value[0];
     //Check in case of bosses with text in the attack (C+1)
     re = new RegExp("(\\d*)(\\+|-)?([a-zA-Z]+)", "i");
     var extra_text_for_particular_bosses = "";
-    var value_parsed = String(normal_attack).match(re);
+    var value_parsed = re.exec(String(normal_attack));
     if (value_parsed && value_parsed[3])
     {
         var symbol = (value_parsed[2] == "-") ? "-" : "+";
@@ -78,28 +78,27 @@ function expand_stat(s, stat, value)
     }
 
     if (line_parsed) {
-        var rest_of_line = line_parsed[3] ? line_parsed[3] : "";
-        if (line_parsed[1] == "+")
+        if (line_parsed[1] === "+")
         {
             var value_normal = normal_attack + parseInt(line_parsed[2]);
             if (has_elite_value)
             {
                 var value_elite = value[1] + parseInt(line_parsed[2]);
-                return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>" + rest_of_line);
+                return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>");
             } else
             {
-                 return ("%" + stat + "% " + extra_text_for_particular_bosses + value_normal + rest_of_line);
+                 return ("%" + stat + "% " + extra_text_for_particular_bosses + value_normal);
             }
-        } else if (line_parsed[1] == "-")
+        } else if (line_parsed[1] === "-")
         {
             var value_normal = normal_attack - parseInt(line_parsed[2]);
             if (has_elite_value)
             {
                 var value_elite = value[1] - parseInt(line_parsed[2]);
-                return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>" + rest_of_line);
+                return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>");
             } else
             {
-                 return ("%" + stat + "% " + extra_text_for_particular_bosses + value_normal + rest_of_line);
+                 return ("%" + stat + "% " + extra_text_for_particular_bosses + value_normal);
             }
         }
     }
@@ -203,9 +202,21 @@ function special_to_lines(s, special1, special2)
 
 function expand_string(s, attack, move, range)
 {
-    s = expand_stat(s, "attack", attack);
-    s = expand_stat(s, "move", move);
-    s = expand_stat(s, "range", range);
+    var re = new RegExp("%(attack|move|range)% (\\+|-)(\\d*)", "g");
+    
+    while (found = re.exec(s))
+    {
+        if (found[1] === "attack")
+        {
+            s = s.replace(found[0], expand_stat(found[0], "attack", attack));
+        } else if  (found[1] === "move")
+        {
+            s = s.replace(found[0], expand_stat(found[0], "move", move));
+        } else if (found[1] === "range")
+        {
+            s = s.replace(found[0], expand_stat(found[0], "range", range));
+        }
+    }
 
     return s.replace(/%[^%]*%/gi, expand_macro);
 }

--- a/macros.js
+++ b/macros.js
@@ -58,31 +58,44 @@ function expand_macro(macro)
 
 function expand_stat(s, stat, value)
 {
-    var re = new RegExp("%" + stat + "% (\\+|-)(\\d)+", "i");
-    var found = s.match(re);
+    var re = new RegExp("%" + stat + "% (\\+|-)(\\d*)", "i");
+    var line_parsed = s.match(re);
+
     var has_elite_value = (value.length == 2);
-    if (found) {
-      if (found[1] == "+")
+    var normal_attack = value[0];
+    //Check in case of bosses with text in the attack
+    re = new RegExp("(\\d*)(\\+|-)?([a-zA-Z]+)", "i");
+    var extra_text_for_particular_bosses = "";
+    var value_parsed = String(normal_attack).match(re);
+    if (value_parsed && value_parsed[3])
+    {
+        var symbol = (value_parsed[2] == "-") ? "-" : "+";
+        extra_text_for_particular_bosses = value_parsed[3] + symbol;
+        normal_attack = value_parsed[1] !== "" ? parseInt(value_parsed[1]) : 0;
+    }
+
+    if (line_parsed) {
+      if (line_parsed[1] == "+")
       {
-            var value_normal = value[0] + parseInt(found[2]);
+            var value_normal = normal_attack + parseInt(line_parsed[2]);
             if (has_elite_value)
             {
-                var value_elite = value[1] + parseInt(found[2]);
+                var value_elite = value[1] + parseInt(line_parsed[2]);
                 return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>");
             } else 
             {
-                 return ("%" + stat + "% " + value_normal );
+                 return ("%" + stat + "% " + extra_text_for_particular_bosses + value_normal);
             }
-      } else if (found[1] == "-")
+      } else if (line_parsed[1] == "-")
       {
-            var value_normal = value[0] - parseInt(found[2]);
+            var value_normal = normal_attack - parseInt(line_parsed[2]);
             if (has_elite_value)
             {
-                var value_elite = value[1] - parseInt(found[2]);
+                var value_elite = value[1] - parseInt(line_parsed[2]);
                 return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>");
             } else 
             {
-                 return ("%" + stat + "% " + value_normal );
+                 return ("%" + stat + "% " + extra_text_for_particular_bosses + value_normal );
             }
       }
     }
@@ -92,7 +105,7 @@ function expand_stat(s, stat, value)
 
 function attributes_to_lines(attributes)
 {
-    if (!attributes[0] && !attributes[1])
+    if (!attributes || (attributes[0].length == 0 && attributes[1].length == 0))
     {
         return [""];
     } else
@@ -111,7 +124,7 @@ function attributes_to_lines(attributes)
                 line++;
             }
         }
-        attributes_lines = attributes_lines.concat(normal_attributes_lines.map(function(line) { return line ? "** <span class='small'>" + line.replace(/(,\s$)/g, "") + "</span>" : "" }));
+        attributes_lines = attributes_lines.concat(normal_attributes_lines.map(function(line) { return line ? "** <span class='small'>" + line.replace(/(,\s$)/g, "") + "</span>" : "";}));
 
         // Write elite only attributes in Gold
         var elite_attributes_lines = [""];
@@ -129,8 +142,7 @@ function attributes_to_lines(attributes)
                 line++;
             }
         }
-        attributes_lines = attributes_lines.concat(elite_attributes_lines.map(function(line) { console.log(line.replace(/(,\s$)/g, "")); return line ? "** <span class='small elite-color'>" + line.replace(/(,\s$)/g, "") + "</span>" : "";}));
-        console.log(attributes_lines);
+        attributes_lines = attributes_lines.concat(elite_attributes_lines.map(function(line) { return line ? "** <span class='small elite-color'>" + line.replace(/(,\s$)/g, "") + "</span>" : "";}));
 
         return attributes_lines;
     }
@@ -157,6 +169,11 @@ function immunities_to_lines(immunities)
         var result = ["* Immunities"].concat(immunities_lines.map(function(line) { return "** <span class='small'>" + line.replace(/(,\s$)/g, "") + "</span>"}));
         return result;
     }
+}
+
+function notes_to_lines(notes)
+{
+    return ["* <span class='small'> Notes: " + notes + "</span>"];
 }
 
 function expand_special(s, special_value)

--- a/macros.js
+++ b/macros.js
@@ -1,6 +1,6 @@
 
 /* Macros used in card text, alphabetical order */
-MACROS =    
+MACROS =
     { "%air%":                                      "<img class='element' src='images/air.svg'>"
     , "%any%":                                      "<img class='element' src='images/any_element.svg'>"
     , "%aoe-4-with-black%":                         "<img class='aoe h2' src='images/aoe-4-with-black.svg'>"
@@ -56,8 +56,135 @@ function expand_macro(macro)
     }
 }
 
-function expand_string(s)
+function expand_stat(s, stat, value)
 {
+    var re = new RegExp("%" + stat + "% (\\+|-)(\\d)+", "i");
+    var found = s.match(re);
+    var has_elite_value = (value.length == 2);
+    if (found) {
+      if (found[1] == "+")
+      {
+            var value_normal = value[0] + parseInt(found[2]);
+            if (has_elite_value)
+            {
+                var value_elite = value[1] + parseInt(found[2]);
+                return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>");
+            } else 
+            {
+                 return ("%" + stat + "% " + value_normal );
+            }
+      } else if (found[1] == "-")
+      {
+            var value_normal = value[0] - parseInt(found[2]);
+            if (has_elite_value)
+            {
+                var value_elite = value[1] - parseInt(found[2]);
+                return ("%" + stat + "% " + value_normal + " / <span class='elite-color'>" + value_elite + "</span>");
+            } else 
+            {
+                 return ("%" + stat + "% " + value_normal );
+            }
+      }
+    }
+
+    return s;
+}
+
+function attributes_to_lines(attributes)
+{
+    if (!attributes[0] && !attributes[1])
+    {
+        return [""];
+    } else
+    {
+        // To make it more readable, group 3 elements in the same row abd naje them small
+        var attributes_lines = ["* Attributes"];
+
+        // Write common attributes in white
+        var normal_attributes_lines = [""];
+        var line = 0;
+        for (var i=0; i<attributes[0].length; i++)
+        {
+            normal_attributes_lines[line] = normal_attributes_lines[line] ? normal_attributes_lines[line] + attributes[0][i] + ", " : attributes[0][i] + ", ";
+            if ((i+1) % 3 == 0 )
+            {
+                line++;
+            }
+        }
+        attributes_lines = attributes_lines.concat(normal_attributes_lines.map(function(line) { return line ? "** <span class='small'>" + line.replace(/(,\s$)/g, "") + "</span>" : "" }));
+
+        // Write elite only attributes in Gold
+        var elite_attributes_lines = [""];
+        // TODO
+        // In case we want to show Common and Elite only attributes
+        // var elite_attributes = attributes[1].map(function(elite_attribute){
+        //     return ((attributes[0].indexOf(elite_attribute) == -1) ? elite_attribute: "")
+        // });
+        line = 0;
+        for (var i=0; i<attributes[1].length; i++)
+        {
+            elite_attributes_lines[line] = elite_attributes_lines[line] ? elite_attributes_lines[line] + attributes[1][i] + ", " : attributes[1][i] + ", ";
+            if ((i+1) % 3 == 0 )
+            {
+                line++;
+            }
+        }
+        attributes_lines = attributes_lines.concat(elite_attributes_lines.map(function(line) { console.log(line.replace(/(,\s$)/g, "")); return line ? "** <span class='small elite-color'>" + line.replace(/(,\s$)/g, "") + "</span>" : "";}));
+        console.log(attributes_lines);
+
+        return attributes_lines;
+    }
+}
+
+function immunities_to_lines(immunities)
+{
+    if (!immunities)
+    {
+        return [""];
+    } else
+    {
+        // To make it more readable, group 3 elements in the same row abd naje them small
+        var immunities_lines = [""];
+        var line = 0;
+        for (var i=0; i<immunities.length; i++)
+        {
+            immunities_lines[line] = immunities_lines[line] ? immunities_lines[line] + immunities[i] + ", " : immunities[i] + ", ";
+            if ((i+1) % 3 == 0 )
+            {
+                line++;
+            }
+        }
+        var result = ["* Immunities"].concat(immunities_lines.map(function(line) { return "** <span class='small'>" + line.replace(/(,\s$)/g, "") + "</span>"}));
+        return result;
+    }
+}
+
+function expand_special(s, special_value)
+{
+    var value = "";
+    return special_value.map(function(line){
+        return ("* " + line);
+    });
+}
+
+function special_to_lines(s, special1, special2)
+{
+    if (special1 && s.includes("Special 1"))
+    {
+        s = expand_special(s, special1);
+    }
+    if (special2 && s.includes("Special 2"))
+    {
+        s = expand_special(s, special2);
+    }
+    return s;
+}
+
+function expand_string(s, attack, move, range)
+{
+    s = expand_stat(s, "attack", attack);
+    s = expand_stat(s, "move", move);
+    s = expand_stat(s, "range", range);
     return s.replace(/%[^%]*%/gi, expand_macro);
 }
 

--- a/macros.js
+++ b/macros.js
@@ -3,8 +3,8 @@ MACROS =
     { "%air%":                                      "<img class='element' src='images/air.svg'>"
     , "%any%":                                      "<img class='element' src='images/any_element.svg'>"
     , "%aoe-4-with-black%":                         "<img class='aoe h2' src='images/aoe-4-with-black.svg'>"
-    , "%aoe-circle%":                               "<div class='collapse'><img class='aoe h3' src='images/aoe-circle.svg'></div>"
-    , "%aoe-circle-with-middle-black%":             "<div class='collapse'><img class='aoe h3' src='images/aoe-circle-with-middle-black.svg'></div>"
+    , "%aoe-circle%":                               "<div class='collapse small'><img class='aoe h3' src='images/aoe-circle.svg'></div>"
+    , "%aoe-circle-with-middle-black%":             "<div class='collapse small'><img class='aoe h3' src='images/aoe-circle-with-middle-black.svg'></div>"
     , "%aoe-circle-with-side-black%":               "<img class='aoe h3' src='images/aoe-circle-with-side-black.svg'>"
     , "%aoe-line-3-with-black%":                    "<div class='collapse'><img class='aoe h1 rotated' src='images/aoe-line-3-with-black.svg'></div>"
     , "%aoe-line-4-with-black%":                    "<div class='collapse'><img class='aoe h1 rotated' src='images/aoe-line-4-with-black.svg'></div>"
@@ -66,7 +66,7 @@ function expand_stat(s, stat, value)
     
     var has_elite_value = (value.length == 2);
     var normal_attack = value[0];
-    //Check in case of bosses with text in the attack
+    //Check in case of bosses with text in the attack (C+1)
     re = new RegExp("(\\d*)(\\+|-)?([a-zA-Z]+)", "i");
     var extra_text_for_particular_bosses = "";
     var value_parsed = String(normal_attack).match(re);
@@ -74,7 +74,7 @@ function expand_stat(s, stat, value)
     {
         var symbol = (value_parsed[2] == "-") ? "-" : "+";
         extra_text_for_particular_bosses = value_parsed[3] + symbol;
-        normal_attack = value_parsed[1] !== "" ? parseInt(value_parsed[1]) : 0;
+        normal_attack = (value_parsed[1] !== "") ? parseInt(value_parsed[1]) : 0;
     }
 
     if (line_parsed) {
@@ -111,14 +111,14 @@ function attributes_to_lines(attributes)
 {
     if (!attributes || (attributes[0].length == 0 && attributes[1].length == 0))
     {
-        return [""];
+        return [];
     } else
     {
         // To make it more readable, group 3 elements in the same row abd naje them small
         var attributes_lines = ["* Attributes"];
 
         // Write common attributes in white
-        var normal_attributes_lines = [""];
+        var normal_attributes_lines = [];
         var line = 0;
         for (var i=0; i<attributes[0].length; i++)
         {
@@ -130,8 +130,8 @@ function attributes_to_lines(attributes)
         }
         attributes_lines = attributes_lines.concat(normal_attributes_lines.map(function(line) { return line ? "**" + line.replace(/(,\s$)/g, "") : "";}));
 
-        // Write elite only attributes in Gold
-        var elite_attributes_lines = [""];
+        // Write elite attributes in Gold
+        var elite_attributes_lines = [];
         // TODO
         // In case we want to show Common and Elite only attributes
         // var elite_attributes = attributes[1].map(function(elite_attribute){
@@ -146,9 +146,8 @@ function attributes_to_lines(attributes)
                 line++;
             }
         }
-        attributes_lines = attributes_lines.concat(elite_attributes_lines.map(function(line) { return line ? "** <span class='elite-color'>" + line.replace(/(,\s$)/g, "") + "</span>" : "";}));
-
-        return attributes_lines;
+        
+        return attributes_lines.concat(elite_attributes_lines.map(function(line) { return line ? "** <span class='elite-color'>" + line.replace(/(,\s$)/g, "") + "</span>" : "";}));
     }
 }
 
@@ -156,11 +155,11 @@ function immunities_to_lines(immunities)
 {
     if (!immunities)
     {
-        return [""];
+        return [];
     } else
     {
         // To make it more readable, group 3 elements in the same row abd naje them small
-        var immunities_lines = [""];
+        var immunities_lines = [];
         var line = 0;
         for (var i=0; i<immunities.length; i++)
         {
@@ -170,8 +169,7 @@ function immunities_to_lines(immunities)
                 line++;
             }
         }
-        var result = ["* Immunities"].concat(immunities_lines.map(function(line) { return "** <span class='small'>" + line.replace(/(,\s$)/g, "") + "</span>"}));
-        return result;
+        return ["* Immunities"].concat(immunities_lines.map(function(line) { return "** <span class='small'>" + line.replace(/(,\s$)/g, "") + "</span>"}));
     }
 }
 
@@ -183,6 +181,7 @@ function notes_to_lines(notes)
 function expand_special(s, special_value)
 {
     var value = "";
+
     return special_value.map(function(line){
         return ("* " + line);
     });
@@ -190,14 +189,15 @@ function expand_special(s, special_value)
 
 function special_to_lines(s, special1, special2)
 {
-    if (special1 && s.includes("Special 1"))
+    if (special1 && s.indexOf("Special 1") !== -1)
     {
         s = expand_special(s, special1);
     }
-    if (special2 && s.includes("Special 2"))
+    if (special1 && s.indexOf("Special 2") !== -1)
     {
         s = expand_special(s, special2);
     }
+
     return s;
 }
 
@@ -206,5 +206,6 @@ function expand_string(s, attack, move, range)
     s = expand_stat(s, "attack", attack);
     s = expand_stat(s, "move", move);
     s = expand_stat(s, "range", range);
+
     return s.replace(/%[^%]*%/gi, expand_macro);
 }

--- a/monster_stats.js
+++ b/monster_stats.js
@@ -1,0 +1,8142 @@
+MONSTER_STATS = {
+  "monsters": {
+    "Ancient Artillery": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 4,
+            "move": 0,
+            "attack": 2,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 7,
+            "move": 0,
+            "attack": 3,
+            "range": 5,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 6,
+            "move": 0,
+            "attack": 2,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 9,
+            "move": 0,
+            "attack": 3,
+            "range": 5,
+            "attributes": []
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 7,
+            "move": 0,
+            "attack": 2,
+            "range": 5,
+            "attributes": []
+          },
+          "elite": {
+            "health": 11,
+            "move": 0,
+            "attack": 3,
+            "range": 6,
+            "attributes": []
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 8,
+            "move": 0,
+            "attack": 3,
+            "range": 5,
+            "attributes": []
+          },
+          "elite": {
+            "health": 13,
+            "move": 0,
+            "attack": 4,
+            "range": 6,
+            "attributes": []
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 9,
+            "move": 0,
+            "attack": 4,
+            "range": 5,
+            "attributes": []
+          },
+          "elite": {
+            "health": 13,
+            "move": 0,
+            "attack": 4,
+            "range": 6,
+            "attributes": [
+              "%target% 2"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 11,
+            "move": 0,
+            "attack": 4,
+            "range": 6,
+            "attributes": []
+          },
+          "elite": {
+            "health": 15,
+            "move": 0,
+            "attack": 4,
+            "range": 7,
+            "attributes": [
+              "%target% 2"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 14,
+            "move": 0,
+            "attack": 4,
+            "range": 6,
+            "attributes": []
+          },
+          "elite": {
+            "health": 16,
+            "move": 0,
+            "attack": 5,
+            "range": 7,
+            "attributes": [
+              "%target% 2"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 16,
+            "move": 0,
+            "attack": 4,
+            "range": 7,
+            "attributes": []
+          },
+          "elite": {
+            "health": 20,
+            "move": 0,
+            "attack": 5,
+            "range": 7,
+            "attributes": [
+              "%target% 2"
+            ]
+          }
+        }
+      ]
+    },
+    "Bandit Archer": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 4,
+            "move": 2,
+            "attack": 2,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 6,
+            "move": 2,
+            "attack": 3,
+            "range": 3,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 2,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 7,
+            "move": 2,
+            "attack": 3,
+            "range": 5,
+            "attributes": []
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 6,
+            "move": 3,
+            "attack": 2,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 9,
+            "move": 3,
+            "attack": 3,
+            "range": 5,
+            "attributes": []
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 6,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 10,
+            "move": 3,
+            "attack": 4,
+            "range": 5,
+            "attributes": []
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 8,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 10,
+            "move": 3,
+            "attack": 4,
+            "range": 6,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 10,
+            "move": 3,
+            "attack": 3,
+            "range": 5,
+            "attributes": []
+          },
+          "elite": {
+            "health": 12,
+            "move": 4,
+            "attack": 4,
+            "range": 6,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 10,
+            "move": 3,
+            "attack": 4,
+            "range": 5,
+            "attributes": []
+          },
+          "elite": {
+            "health": 13,
+            "move": 4,
+            "attack": 5,
+            "range": 6,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 13,
+            "move": 3,
+            "attack": 4,
+            "range": 5,
+            "attributes": []
+          },
+          "elite": {
+            "health": 17,
+            "move": 4,
+            "attack": 5,
+            "range": 6,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        }
+      ]
+    },
+    "Bandit Guard": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 9,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 6,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 9,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 6,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 10,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 9,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 10,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 10,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 11,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%muddle%",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 11,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 12,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%muddle%",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 14,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 14,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%muddle%",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 16,
+            "move": 5,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 14,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%muddle%",
+              "%shield% 3"
+            ]
+          }
+        }
+      ]
+    },
+    "Black Imp": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 3,
+            "move": 1,
+            "attack": 1,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 4,
+            "move": 1,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 4,
+            "move": 1,
+            "attack": 1,
+            "range": 3,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 1,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 5,
+            "move": 1,
+            "attack": 1,
+            "range": 4,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 1,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 5,
+            "move": 1,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 1,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%attack%ers gain Disadvantage",
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 7,
+            "move": 1,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 1,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%attack%ers gain Disadvantage",
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 9,
+            "move": 1,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 1,
+            "attack": 3,
+            "range": 5,
+            "attributes": [
+              "%attack%ers gain Disadvantage",
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 10,
+            "move": 1,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 1,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "%attack%ers gain Disadvantage",
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 12,
+            "move": 1,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 17,
+            "move": 1,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "%attack%ers gain Disadvantage",
+              "%poison%"
+            ]
+          }
+        }
+      ]
+    },
+    "Cave Bear": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 7,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 11,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 9,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 14,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 11,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 17,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 13,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 20,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 16,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 21,
+            "move": 5,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 17,
+            "move": 5,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 24,
+            "move": 5,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 19,
+            "move": 5,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 28,
+            "move": 5,
+            "attack": 7,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 22,
+            "move": 5,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 33,
+            "move": 5,
+            "attack": 7,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        }
+      ]
+    },
+    "City Archer": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 4,
+            "move": 1,
+            "attack": 2,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 6,
+            "move": 1,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 5,
+            "move": 1,
+            "attack": 2,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 6,
+            "move": 1,
+            "attack": 3,
+            "range": 5,
+            "attributes": [
+              "%pierce% 1",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 6,
+            "move": 1,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 7,
+            "move": 1,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "%pierce% 2",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 6,
+            "move": 2,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 2,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "%pierce% 2",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 8,
+            "move": 2,
+            "attack": 3,
+            "range": 5,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 10,
+            "move": 2,
+            "attack": 4,
+            "range": 6,
+            "attributes": [
+              "%pierce% 2",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 9,
+            "move": 2,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 2,
+            "attack": 5,
+            "range": 6,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 9,
+            "move": 3,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 3,
+            "attack": 6,
+            "range": 6,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 10,
+            "move": 3,
+            "attack": 4,
+            "range": 6,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 13,
+            "move": 3,
+            "attack": 6,
+            "range": 7,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 3"
+            ]
+          }
+        }
+      ]
+    },
+    "City Guard": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 6,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 7,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 9,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 8,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 9,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 9,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 10,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 10,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2",
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 11,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 13,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3",
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 13,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 3,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3",
+              "%shield% 3"
+            ]
+          }
+        }
+      ]
+    },
+    "Cultist": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 4,
+            "move": 2,
+            "attack": 1,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 7,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 1,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 9,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 7,
+            "move": 2,
+            "attack": 1,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 12,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 9,
+            "move": 3,
+            "attack": 1,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 13,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%curse%"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 10,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 15,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%curse%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 11,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%curse%"
+            ]
+          },
+          "elite": {
+            "health": 18,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%curse%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 14,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%curse%"
+            ]
+          },
+          "elite": {
+            "health": 22,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%curse%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 15,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%curse%"
+            ]
+          },
+          "elite": {
+            "health": 25,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%curse%"
+            ]
+          }
+        }
+      ]
+    },
+    "Deep Terror": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 3,
+            "move": 0,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 5,
+            "move": 0,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 4,
+            "move": 0,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 0,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 4,
+            "move": 0,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 0,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 5,
+            "move": 0,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 0,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 6,
+            "move": 0,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 9,
+            "move": 0,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 7,
+            "move": 0,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 0,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 8,
+            "move": 0,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          },
+          "elite": {
+            "health": 13,
+            "move": 0,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 9,
+            "move": 0,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 0,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          }
+        }
+      ]
+    },
+    "Earth Demon": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 7,
+            "move": 1,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 10,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 9,
+            "move": 1,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 13,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 12,
+            "move": 1,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 18,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 13,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 20,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%immobilize%"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 15,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 21,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%immobilize%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 17,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%immobilize%"
+            ]
+          },
+          "elite": {
+            "health": 25,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%immobilize%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 20,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%immobilize%"
+            ]
+          },
+          "elite": {
+            "health": 27,
+            "move": 3,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%immobilize%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 22,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%immobilize%"
+            ]
+          },
+          "elite": {
+            "health": 32,
+            "move": 3,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%immobilize%"
+            ]
+          }
+        }
+      ]
+    },
+    "Flame Demon": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 2,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "Flying",
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 3,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "Flying",
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 2,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "Flying",
+              "Sheild 3"
+            ]
+          },
+          "elite": {
+            "health": 3,
+            "move": 3,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "Flying",
+              "%retaliate% 2, %range% 2",
+              "%shield% 4"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 3,
+            "move": 3,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "Flying",
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 4,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "Flying",
+              "%retaliate% 3, %range% 2",
+              "%shield% 4"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 3,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "Flying",
+              "%retaliate% 2, %range% 2",
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 5,
+            "move": 3,
+            "attack": 3,
+            "range": 5,
+            "attributes": [
+              "Flying",
+              "%retaliate% 3, %range% 3",
+              "%shield% 4"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 3,
+            "move": 4,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "Flying",
+              "%retaliate% 3, %range% 2",
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 5,
+            "move": 4,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "Flying",
+              "%retaliate% 4, %range% 3",
+              "%shield% 4"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 4,
+            "move": 4,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "Flying",
+              "%retaliate% 3, %range% 2",
+              "%shield% 4"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 4,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "Flying",
+              "%retaliate% 4, %range% 3",
+              "%shield% 5"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 4,
+            "move": 4,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "Flying",
+              "%retaliate% 4, %range% 2",
+              "%shield% 4"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 4,
+            "attack": 5,
+            "range": 5,
+            "attributes": [
+              "Flying",
+              "%retaliate% 5, %range% 3",
+              "%shield% 5"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 5,
+            "move": 4,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "Flying",
+              "%retaliate% 4, %range% 3",
+              "%shield% 4"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 4,
+            "attack": 5,
+            "range": 6,
+            "attributes": [
+              "Flying",
+              "%retaliate% 5, %range% 4",
+              "%shield% 5"
+            ]
+          }
+        }
+      ]
+    },
+    "Frost Demon": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 10,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 6,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 10,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 7,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 8,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 10,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 18,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 11,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          },
+          "elite": {
+            "health": 20,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 12,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          },
+          "elite": {
+            "health": 22,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 14,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          },
+          "elite": {
+            "health": 25,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          }
+        }
+      ]
+    },
+    "Forest Imp": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 1,
+            "move": 3,
+            "attack": 1,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 4,
+            "move": 3,
+            "attack": 1,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 2,
+            "move": 3,
+            "attack": 1,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 5,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 2,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%curse%",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 3,
+            "move": 4,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 4,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%curse%",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 3,
+            "move": 4,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 4,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%curse%",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 4,
+            "move": 4,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%curse%",
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 4,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%curse%",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 4,
+            "move": 4,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%curse%",
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 9,
+            "move": 4,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%curse%",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 6,
+            "move": 4,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%curse%",
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 4,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%curse%",
+              "%shield% 2"
+            ]
+          }
+        }
+      ]
+    },
+    "Giant Viper": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 2,
+            "move": 2,
+            "attack": 1,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 3,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 3,
+            "move": 2,
+            "attack": 1,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 5,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 4,
+            "move": 3,
+            "attack": 1,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 4,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 6,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 7,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 13,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 8,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 10,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 17,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        }
+      ]
+    },
+    "Harrower Infester": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 6,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 12,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 7,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 8,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 10,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 17,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 12,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 19,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 12,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          },
+          "elite": {
+            "health": 21,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 15,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          },
+          "elite": {
+            "health": 22,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 17,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          },
+          "elite": {
+            "health": 26,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          }
+        }
+      ]
+    },
+    "Hound": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 4,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 6,
+            "move": 5,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 4,
+            "move": 4,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 5,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 6,
+            "move": 4,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 5,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 8,
+            "move": 4,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 5,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 8,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 5,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 9,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 5,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 11,
+            "move": 5,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 6,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 15,
+            "move": 5,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 6,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          }
+        }
+      ]
+    },
+    "Inox Archer": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 2,
+            "range": 2,
+            "attributes": []
+          },
+          "elite": {
+            "health": 7,
+            "move": 2,
+            "attack": 3,
+            "range": 3,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 6,
+            "move": 2,
+            "attack": 2,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 8,
+            "move": 2,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 8,
+            "move": 2,
+            "attack": 2,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 11,
+            "move": 2,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 9,
+            "move": 2,
+            "attack": 3,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 13,
+            "move": 2,
+            "attack": 4,
+            "range": 4,
+            "attributes": []
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 10,
+            "move": 3,
+            "attack": 3,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 14,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 12,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 17,
+            "move": 3,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 12,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 19,
+            "move": 3,
+            "attack": 5,
+            "range": 5,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 15,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 23,
+            "move": 3,
+            "attack": 5,
+            "range": 5,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        }
+      ]
+    },
+    "Inox Guard": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 9,
+            "move": 1,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 8,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 10,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 9,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 12,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 11,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 15,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 12,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 17,
+            "move": 2,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 3"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 13,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 19,
+            "move": 2,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 16,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 1"
+            ]
+          },
+          "elite": {
+            "health": 21,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 19,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 2"
+            ]
+          },
+          "elite": {
+            "health": 23,
+            "move": 3,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%retaliate% 4"
+            ]
+          }
+        }
+      ]
+    },
+    "Inox Shaman": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 4,
+            "move": 1,
+            "attack": 2,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 6,
+            "move": 2,
+            "attack": 3,
+            "range": 3,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 6,
+            "move": 1,
+            "attack": 2,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 9,
+            "move": 2,
+            "attack": 3,
+            "range": 3,
+            "attributes": []
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 7,
+            "move": 2,
+            "attack": 2,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 11,
+            "move": 3,
+            "attack": 3,
+            "range": 3,
+            "attributes": []
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 9,
+            "move": 2,
+            "attack": 2,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 14,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 10,
+            "move": 2,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 16,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": []
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 13,
+            "move": 2,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 20,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": []
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 15,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 24,
+            "move": 4,
+            "attack": 4,
+            "range": 4,
+            "attributes": []
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 16,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": []
+          },
+          "elite": {
+            "health": 27,
+            "move": 4,
+            "attack": 5,
+            "range": 4,
+            "attributes": []
+          }
+        }
+      ]
+    },
+    "Living Bones": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 1,
+            "range": 0,
+            "attributes": [
+              "%target% 2"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 4,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%target% 2"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 5,
+            "move": 3,
+            "attack": 1,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 4,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%target% 3",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 5,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 3",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 7,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 10,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 3",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 7,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%target% 3",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 9,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%target% 3",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 10,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 6,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%target% 3",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 13,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 6,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%target% 3",
+              "%shield% 2"
+            ]
+          }
+        }
+      ]
+    },
+    "Living Corpse": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 1,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 10,
+            "move": 1,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 7,
+            "move": 1,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 10,
+            "move": 1,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 9,
+            "move": 1,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 13,
+            "move": 1,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 10,
+            "move": 1,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 13,
+            "move": 2,
+            "attack": 5,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 11,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 15,
+            "move": 2,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 13,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 17,
+            "move": 2,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 14,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 21,
+            "move": 2,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 15,
+            "move": 2,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 25,
+            "move": 2,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          }
+        }
+      ]
+    },
+    "Living Spirit": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 2,
+            "move": 2,
+            "attack": 2,
+            "range": 2,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 3,
+            "move": 3,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 2,
+            "move": 2,
+            "attack": 2,
+            "range": 2,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 3,
+            "move": 3,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 2,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 3,
+            "move": 4,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 3,
+            "move": 3,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 4,
+            "move": 4,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 3,
+            "move": 3,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 4,
+            "move": 4,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%shield% 4"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 4,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 4,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%shield% 4"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 4,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 4,
+            "attack": 5,
+            "range": 5,
+            "attributes": [
+              "%shield% 4"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 6,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 9,
+            "move": 4,
+            "attack": 5,
+            "range": 5,
+            "attributes": [
+              "%shield% 4"
+            ]
+          }
+        }
+      ]
+    },
+    "Lurker": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%target% 2"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 7,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 1"
+            ]
+          },
+          "elite": {
+            "health": 9,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 1",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 9,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 1"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 2",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 10,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 2"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 2",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 10,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 2",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 3",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 11,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 2",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 3",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 12,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 3",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 16,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 4",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 14,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 3",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 18,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%target% 2",
+              "%pierce% 4",
+              "%shield% 2"
+            ]
+          }
+        }
+      ]
+    },
+    "Ooze": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 4,
+            "move": 1,
+            "attack": 2,
+            "range": 2,
+            "attributes": []
+          },
+          "elite": {
+            "health": 8,
+            "move": 1,
+            "attack": 2,
+            "range": 3,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 5,
+            "move": 1,
+            "attack": 2,
+            "range": 2,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 9,
+            "move": 1,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 7,
+            "move": 1,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 1,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 8,
+            "move": 1,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 2,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%poison%",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 9,
+            "move": 2,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 13,
+            "move": 2,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%poison%",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 10,
+            "move": 2,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%poison%",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%poison%",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 12,
+            "move": 2,
+            "attack": 4,
+            "range": 3,
+            "attributes": [
+              "%poison%",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 16,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%poison%",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 14,
+            "move": 2,
+            "attack": 4,
+            "range": 3,
+            "attributes": [
+              "%poison%",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 18,
+            "move": 3,
+            "attack": 5,
+            "range": 4,
+            "attributes": [
+              "%poison%",
+              "%shield% 2"
+            ]
+          }
+        }
+      ]
+    },
+    "Night Demon": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 3,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          },
+          "elite": {
+            "health": 5,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 5,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 6,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 7,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          },
+          "elite": {
+            "health": 13,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 8,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 5,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 11,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          },
+          "elite": {
+            "health": 17,
+            "move": 5,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 14,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          },
+          "elite": {
+            "health": 21,
+            "move": 5,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 15,
+            "move": 4,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          },
+          "elite": {
+            "health": 21,
+            "move": 5,
+            "attack": 8,
+            "range": 0,
+            "attributes": [
+              "%attack%ers gain Disadvantage"
+            ]
+          }
+        }
+      ]
+    },
+    "Rending Drake": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 7,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 6,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 7,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 9,
+            "move": 5,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 7,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 10,
+            "move": 5,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 9,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 6,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 10,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 6,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 11,
+            "move": 5,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 6,
+            "attack": 7,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 14,
+            "move": 5,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 18,
+            "move": 6,
+            "attack": 7,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        }
+      ]
+    },
+    "Savvas Icestorm": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 7,
+            "move": 2,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%pierce% 3"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 2,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%pierce% 3"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 10,
+            "move": 2,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%pierce% 3"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 2,
+            "attack": 3,
+            "range": 5,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 12,
+            "move": 3,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%pierce% 3"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 3,
+            "attack": 3,
+            "range": 5,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 12,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 18,
+            "move": 3,
+            "attack": 4,
+            "range": 6,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 14,
+            "move": 3,
+            "attack": 3,
+            "range": 5,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 19,
+            "move": 4,
+            "attack": 4,
+            "range": 6,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 16,
+            "move": 3,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 21,
+            "move": 4,
+            "attack": 5,
+            "range": 6,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 16,
+            "move": 3,
+            "attack": 4,
+            "range": 5,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 23,
+            "move": 4,
+            "attack": 6,
+            "range": 6,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 17,
+            "move": 4,
+            "attack": 4,
+            "range": 6,
+            "attributes": [
+              "%pierce% 3",
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 24,
+            "move": 4,
+            "attack": 6,
+            "range": 6,
+            "attributes": [
+              "%pierce% 4",
+              "%shield% 3"
+            ]
+          }
+        }
+      ]
+    },
+    "Savvas Lavaflow": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 8,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 13,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 9,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 11,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 18,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%poison%",
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 14,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 21,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%poison%",
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 16,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%poison%"
+            ]
+          },
+          "elite": {
+            "health": 24,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%poison%",
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 18,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%poison%",
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 27,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%poison%",
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 20,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%poison%",
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 30,
+            "move": 4,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%poison%",
+              "%wound%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 24,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%poison%",
+              "%wound%"
+            ]
+          },
+          "elite": {
+            "health": 35,
+            "move": 4,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%poison%",
+              "%wound%"
+            ]
+          }
+        }
+      ]
+    },
+    "Spitting Drake": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 3,
+            "attack": 3,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 8,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 6,
+            "move": 3,
+            "attack": 3,
+            "range": 3,
+            "attributes": []
+          },
+          "elite": {
+            "health": 9,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%muddle%"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 8,
+            "move": 3,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%muddle%"
+            ]
+          },
+          "elite": {
+            "health": 10,
+            "move": 3,
+            "attack": 5,
+            "range": 4,
+            "attributes": [
+              "%muddle%"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 8,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%muddle%"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 3,
+            "attack": 5,
+            "range": 5,
+            "attributes": [
+              "%muddle%"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 9,
+            "move": 4,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%muddle%"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 4,
+            "attack": 5,
+            "range": 5,
+            "attributes": [
+              "%muddle%"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 12,
+            "move": 4,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%muddle%"
+            ]
+          },
+          "elite": {
+            "health": 16,
+            "move": 4,
+            "attack": 6,
+            "range": 5,
+            "attributes": [
+              "%muddle%"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 13,
+            "move": 4,
+            "attack": 5,
+            "range": 4,
+            "attributes": [
+              "%muddle%"
+            ]
+          },
+          "elite": {
+            "health": 19,
+            "move": 4,
+            "attack": 6,
+            "range": 5,
+            "attributes": [
+              "%muddle%"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 16,
+            "move": 4,
+            "attack": 5,
+            "range": 4,
+            "attributes": [
+              "%muddle%"
+            ]
+          },
+          "elite": {
+            "health": 21,
+            "move": 4,
+            "attack": 7,
+            "range": 5,
+            "attributes": [
+              "%muddle%"
+            ]
+          }
+        }
+      ]
+    },
+    "Stone Golem": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 10,
+            "move": 1,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 10,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 10,
+            "move": 1,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 11,
+            "move": 1,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 14,
+            "move": 2,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 11,
+            "move": 1,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 2,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 12,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 17,
+            "move": 2,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 13,
+            "move": 2,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 19,
+            "move": 3,
+            "attack": 6,
+            "range": 0,
+            "attributes": [
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 16,
+            "move": 2,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 20,
+            "move": 3,
+            "attack": 7,
+            "range": 0,
+            "attributes": [
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 16,
+            "move": 2,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 21,
+            "move": 3,
+            "attack": 7,
+            "range": 0,
+            "attributes": [
+              "%shield% 4"
+            ]
+          }
+        }
+      ]
+    },
+    "Sun Demon": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 5,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 9,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 7,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 9,
+            "move": 2,
+            "attack": 2,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 13,
+            "move": 2,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 10,
+            "move": 2,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 15,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 11,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 16,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 11,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 16,
+            "move": 3,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 12,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 18,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 15,
+            "move": 3,
+            "attack": 4,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 22,
+            "move": 4,
+            "attack": 5,
+            "range": 0,
+            "attributes": [
+              "Advantage",
+              "%shield% 2"
+            ]
+          }
+        }
+      ]
+    },
+    "Vermling Scout": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 2,
+            "move": 3,
+            "attack": 1,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 4,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 3,
+            "move": 3,
+            "attack": 1,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 5,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 3,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 5,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 5,
+            "move": 3,
+            "attack": 2,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 7,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 6,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 8,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 8,
+            "move": 3,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 11,
+            "move": 4,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 9,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 12,
+            "move": 5,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 11,
+            "move": 4,
+            "attack": 3,
+            "range": 0,
+            "attributes": []
+          },
+          "elite": {
+            "health": 15,
+            "move": 5,
+            "attack": 4,
+            "range": 0,
+            "attributes": []
+          }
+        }
+      ]
+    },
+    "Vermling Shaman": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 2,
+            "move": 2,
+            "attack": 1,
+            "range": 3,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 3,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 2,
+            "move": 2,
+            "attack": 1,
+            "range": 3,
+            "attributes": [
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 3,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 3,
+            "move": 2,
+            "attack": 1,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 4,
+            "move": 3,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 3,
+            "move": 2,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 5,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 3,
+            "move": 3,
+            "attack": 2,
+            "range": 4,
+            "attributes": [
+              "%muddle%",
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 5,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%muddle%",
+              "%shield% 4"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 4,
+            "move": 3,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%muddle%",
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%muddle%",
+              "%shield% 4"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 5,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%muddle%",
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 6,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%muddle%",
+              "%shield% 5"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 7,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%muddle%",
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 3,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%muddle%",
+              "%shield% 5"
+            ]
+          }
+        }
+      ]
+    },
+    "Wind Demon": {
+      "level": [
+        {
+          "level": 0,
+          "normal": {
+            "health": 3,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%shield% 1"
+            ]
+          },
+          "elite": {
+            "health": 5,
+            "move": 4,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%shield% 1"
+            ]
+          }
+        },
+        {
+          "level": 1,
+          "normal": {
+            "health": 3,
+            "move": 3,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 5,
+            "move": 4,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 2,
+          "normal": {
+            "health": 4,
+            "move": 4,
+            "attack": 2,
+            "range": 3,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 7,
+            "move": 5,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 3,
+          "normal": {
+            "health": 5,
+            "move": 4,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 5,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 4,
+          "normal": {
+            "health": 7,
+            "move": 4,
+            "attack": 3,
+            "range": 3,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 8,
+            "move": 5,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%disarm%",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 5,
+          "normal": {
+            "health": 9,
+            "move": 4,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%shield% 2"
+            ]
+          },
+          "elite": {
+            "health": 11,
+            "move": 5,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%disarm%",
+              "%shield% 2"
+            ]
+          }
+        },
+        {
+          "level": 6,
+          "normal": {
+            "health": 10,
+            "move": 4,
+            "attack": 3,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 12,
+            "move": 5,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%disarm%",
+              "%shield% 3"
+            ]
+          }
+        },
+        {
+          "level": 7,
+          "normal": {
+            "health": 11,
+            "move": 4,
+            "attack": 4,
+            "range": 4,
+            "attributes": [
+              "%shield% 3"
+            ]
+          },
+          "elite": {
+            "health": 13,
+            "move": 5,
+            "attack": 5,
+            "range": 4,
+            "attributes": [
+              "%disarm%",
+              "%shield% 3"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "bosses": {
+    "Bandit Commander": {
+      "level": [
+        {
+          "level": 0,
+          "health": "8xC",
+          "move": 3,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "%move% to next door and reveal room"
+          ],
+          "special2": [
+            "Summon Living Bones"
+          ],
+          "immunities": [
+            "%stun%",
+            "%immobilize%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "10xC",
+          "move": 3,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "%move% to next door and reveal room"
+          ],
+          "special2": [
+            "Summon Living Bones"
+          ],
+          "immunities": [
+            "%stun%",
+            "%immobilize%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "12xC",
+          "move": 4,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "%move% to next door and reveal room"
+          ],
+          "special2": [
+            "Summon Living Bones"
+          ],
+          "immunities": [
+            "%stun%",
+            "%immobilize%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "13xC",
+          "move": 4,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%move% to next door and reveal room"
+          ],
+          "special2": [
+            "Summon Living Bones"
+          ],
+          "immunities": [
+            "%stun%",
+            "%immobilize%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "15xC",
+          "move": 4,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%move% to next door and reveal room"
+          ],
+          "special2": [
+            "Summon Living Bones"
+          ],
+          "immunities": [
+            "%stun%",
+            "%immobilize%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "16xC",
+          "move": 5,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%move% to next door and reveal room"
+          ],
+          "special2": [
+            "Summon Living Bones"
+          ],
+          "immunities": [
+            "%stun%",
+            "%immobilize%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "19xC",
+          "move": 5,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%move% to next door and reveal room"
+          ],
+          "special2": [
+            "Summon Living Bones"
+          ],
+          "immunities": [
+            "%stun%",
+            "%immobilize%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "23xC",
+          "move": 5,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%move% to next door and reveal room"
+          ],
+          "special2": [
+            "Summon Living Bones"
+          ],
+          "immunities": [
+            "%stun%",
+            "%immobilize%",
+            "%curse%"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    "The Betrayer": {
+      "level": [
+        {
+          "level": 0,
+          "health": "10xC",
+          "move": 3,
+          "attack": 4,
+          "range": 3,
+          "special1": [
+            "Summon Giant Viper and Fear"
+          ],
+          "special2": [
+            "Mind Control"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%stun%",
+            "%disarm%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "12xC",
+          "move": 3,
+          "attack": 5,
+          "range": 3,
+          "special1": [
+            "Summon Giant Viper and Fear"
+          ],
+          "special2": [
+            "Mind Control"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%stun%",
+            "%disarm%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "14xC",
+          "move": 3,
+          "attack": 6,
+          "range": 4,
+          "special1": [
+            "Summon Giant Viper and Fear"
+          ],
+          "special2": [
+            "Mind Control"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%stun%",
+            "%disarm%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "16xC",
+          "move": 4,
+          "attack": 7,
+          "range": 4,
+          "special1": [
+            "Summon Giant Viper and Fear"
+          ],
+          "special2": [
+            "Mind Control"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%stun%",
+            "%disarm%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "18xC",
+          "move": 4,
+          "attack": 8,
+          "range": 4,
+          "special1": [
+            "Summon Giant Viper and Fear"
+          ],
+          "special2": [
+            "Mind Control"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%stun%",
+            "%disarm%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "20xC",
+          "move": 5,
+          "attack": 8,
+          "range": 5,
+          "special1": [
+            "Summon Giant Viper and Fear"
+          ],
+          "special2": [
+            "Mind Control"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%stun%",
+            "%disarm%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "23xC",
+          "move": 5,
+          "attack": 9,
+          "range": 5,
+          "special1": [
+            "Summon Giant Viper and Fear"
+          ],
+          "special2": [
+            "Mind Control"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%stun%",
+            "%disarm%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "27xC",
+          "move": 5,
+          "attack": 9,
+          "range": 5,
+          "special1": [
+            "Summon Giant Viper and Fear"
+          ],
+          "special2": [
+            "Mind Control"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%stun%",
+            "%disarm%",
+            "%curse%"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    "Captain of the Guard": {
+      "level": [
+        {
+          "level": 0,
+          "health": "7xC",
+          "move": 2,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "%heal% 2, Affect self and all allies"
+          ],
+          "special2": [
+            "All allies add +1 Attack to all attacks this round",
+            "%attack% +1"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "9xC",
+          "move": 2,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "%heal% 2, Affect self and all allies"
+          ],
+          "special2": [
+            "All allies add +1 Attack to all attacks this round",
+            "%attack% +1"
+          ],
+          "immunities": [],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "11xC",
+          "move": 2,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%heal% 2, Affect self and all allies"
+          ],
+          "special2": [
+            "All allies add +1 Attack to all attacks this round",
+            "%attack% +1"
+          ],
+          "immunities": [],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "14xC",
+          "move": 3,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%heal% 2, Affect self and all allies"
+          ],
+          "special2": [
+            "All allies add +1 Attack to all attacks this round",
+            "%attack% +1"
+          ],
+          "immunities": [],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "16xC",
+          "move": 3,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%heal% 2, Affect self and all allies"
+          ],
+          "special2": [
+            "All allies add +1 Attack to all attacks this round",
+            "%attack% +1"
+          ],
+          "immunities": [],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "20xC",
+          "move": 3,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%heal% 2, Affect self and all allies"
+          ],
+          "special2": [
+            "All allies add +1 Attack to all attacks this round",
+            "%attack% +1"
+          ],
+          "immunities": [],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "21xC",
+          "move": 4,
+          "attack": 6,
+          "range": 0,
+          "special1": [
+            "%heal% 2, Affect self and all allies"
+          ],
+          "special2": [
+            "All allies add +1 Attack to all attacks this round",
+            "%attack% +1"
+          ],
+          "immunities": [],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "25xC",
+          "move": 4,
+          "attack": 6,
+          "range": 0,
+          "special1": [
+            "%heal% 2, Affect self and all allies"
+          ],
+          "special2": [
+            "All allies add +1 Attack to all attacks this round",
+            "%attack% +1"
+          ],
+          "immunities": [],
+          "notes": ""
+        }
+      ]
+    },
+    "The Colorless": {
+      "level": [
+        {
+          "level": 0,
+          "health": "9xC",
+          "move": 3,
+          "attack": 2,
+          "range": 0,
+          "special1": [
+            "%dark%%use_element%: Summon Night Demon",
+            "%invisible%, Self"
+          ],
+          "special2": [
+            "%light%%use_element%: Summon Sun Demon",
+            "%heal% 4, Self",
+            "%shield% 1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "10xC",
+          "move": 3,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "%dark%%use_element%: Summon Night Demon",
+            "%invisible%, Self"
+          ],
+          "special2": [
+            "%light%%use_element%: Summon Sun Demon",
+            "%heal% 4, Self",
+            "%shield% 1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "11xC",
+          "move": 4,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "%dark%%use_element%: Summon Night Demon",
+            "%invisible%, Self"
+          ],
+          "special2": [
+            "%light%%use_element%: Summon Sun Demon",
+            "%heal% 5, Self",
+            "%shield% 1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "12xC",
+          "move": 4,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%dark%%use_element%: Summon Night Demon",
+            "%invisible%, Self"
+          ],
+          "special2": [
+            "%light%%use_element%: Summon Sun Demon",
+            "%heal% 5, Self",
+            "%shield% 1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "14xC",
+          "move": 4,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%dark%%use_element%: Summon Night Demon",
+            "%invisible%, Self"
+          ],
+          "special2": [
+            "%light%%use_element%: Summon Sun Demon",
+            "%heal% 6, Self",
+            "%shield% 1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "15xC",
+          "move": 4,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%dark%%use_element%: Summon Night Demon",
+            "%invisible%, Self"
+          ],
+          "special2": [
+            "%light%%use_element%: Summon Sun Demon",
+            "%heal% 6, Self",
+            "%shield% 1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "17xC",
+          "move": 4,
+          "attack": 6,
+          "range": 0,
+          "special1": [
+            "%dark%%use_element%: Summon Night Demon",
+            "%invisible%, Self"
+          ],
+          "special2": [
+            "%light%%use_element%: Summon Sun Demon",
+            "%heal% 7, Self",
+            "%shield% 1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "19xC",
+          "move": 5,
+          "attack": 7,
+          "range": 0,
+          "special1": [
+            "%dark%%use_element%: Summon Night Demon",
+            "%invisible%, Self"
+          ],
+          "special2": [
+            "%light%%use_element%: Summon Sun Demon",
+            "%heal% 7, Self",
+            "%shield% 1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    "Dark Rider": {
+      "level": [
+        {
+          "level": 0,
+          "health": "9xC",
+          "move": 2,
+          "attack": "3+X",
+          "range": 0,
+          "special1": [
+            "%move% +2",
+            "%attack% +0"
+          ],
+          "special2": [
+            "%move% +0",
+            "Summon Imp",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%immobilize%",
+            "%poison%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": "X = Hexes moved"
+        },
+        {
+          "level": 1,
+          "health": "10xC",
+          "move": 3,
+          "attack": "3+X",
+          "range": 0,
+          "special1": [
+            "%move% +2",
+            "%attack% +0"
+          ],
+          "special2": [
+            "%move% +0",
+            "Summon Imp",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%immobilize%",
+            "%poison%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": "X = Hexes moved"
+        },
+        {
+          "level": 2,
+          "health": "12xC",
+          "move": 3,
+          "attack": "3+X",
+          "range": 0,
+          "special1": [
+            "%move% +2",
+            "%attack% +0"
+          ],
+          "special2": [
+            "%move% +0",
+            "Summon Imp",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%immobilize%",
+            "%poison%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": "X = Hexes moved"
+        },
+        {
+          "level": 3,
+          "health": "13xC",
+          "move": 3,
+          "attack": "4+X",
+          "range": 0,
+          "special1": [
+            "%move% +2",
+            "%attack% +0"
+          ],
+          "special2": [
+            "%move% +0",
+            "Summon Imp",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%immobilize%",
+            "%poison%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": "X = Hexes moved"
+        },
+        {
+          "level": 4,
+          "health": "15xC",
+          "move": 3,
+          "attack": "4+X",
+          "range": 0,
+          "special1": [
+            "%move% +2",
+            "%attack% +0"
+          ],
+          "special2": [
+            "%move% +0",
+            "Summon Imp",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%immobilize%",
+            "%poison%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": "X = Hexes moved"
+        },
+        {
+          "level": 5,
+          "health": "16xC",
+          "move": 3,
+          "attack": "5+X",
+          "range": 0,
+          "special1": [
+            "%move% +2",
+            "%attack% +0"
+          ],
+          "special2": [
+            "%move% +0",
+            "Summon Imp",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%immobilize%",
+            "%poison%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": "X = Hexes moved"
+        },
+        {
+          "level": 6,
+          "health": "16xC",
+          "move": 4,
+          "attack": "5+X",
+          "range": 0,
+          "special1": [
+            "%move% +2",
+            "%attack% +0"
+          ],
+          "special2": [
+            "%move% +0",
+            "Summon Imp",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%immobilize%",
+            "%poison%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": "X = Hexes moved"
+        },
+        {
+          "level": 7,
+          "health": "18xC",
+          "move": 4,
+          "attack": "6+X",
+          "range": 0,
+          "special1": [
+            "%move% +2",
+            "%attack% +0"
+          ],
+          "special2": [
+            "%move% +0",
+            "Summon Imp",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%immobilize%",
+            "%poison%",
+            "%stun%",
+            "%disarm%"
+          ],
+          "notes": "X = Hexes moved"
+        }
+      ]
+    },
+    "Elder Drake": {
+      "level": [
+        {
+          "level": 0,
+          "health": "11xC",
+          "move": 0,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "%attack% +0 {{resources.elderDrake.special1Area}}"
+          ],
+          "special2": [
+            "%move% and summon 2 Zephyrs"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "12xC",
+          "move": 0,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%attack% +0 {{resources.elderDrake.special1Area}}"
+          ],
+          "special2": [
+            "%move% and summon 2 Zephyrs"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "15xC",
+          "move": 0,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%attack% +0 {{resources.elderDrake.special1Area}}"
+          ],
+          "special2": [
+            "%move% and summon 2 Zephyrs"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "16xC",
+          "move": 0,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%attack% +0 {{resources.elderDrake.special1Area}}"
+          ],
+          "special2": [
+            "%move% and summon 2 Zephyrs"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "20xC",
+          "move": 0,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%attack% +0 {{resources.elderDrake.special1Area}}"
+          ],
+          "special2": [
+            "%move% and summon 2 Zephyrs"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "22xC",
+          "move": 0,
+          "attack": 6,
+          "range": 0,
+          "special1": [
+            "%attack% +0 {{resources.elderDrake.special1Area}}"
+          ],
+          "special2": [
+            "%move% and summon 2 Zephyrs"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "27xC",
+          "move": 0,
+          "attack": 6,
+          "range": 0,
+          "special1": [
+            "%attack% +0 {{resources.elderDrake.special1Area}}"
+          ],
+          "special2": [
+            "%move% and summon 2 Zephyrs"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "29xC",
+          "move": 0,
+          "attack": 7,
+          "range": 0,
+          "special1": [
+            "%attack% +0 {{resources.elderDrake.special1Area}}"
+          ],
+          "special2": [
+            "%move% and summon 2 Zephyrs"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%stun%"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    "The Gloom": {
+      "level": [
+        {
+          "level": 0,
+          "health": "20xC",
+          "move": 2,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%move% +9",
+            "%attack% +9"
+          ],
+          "special2": [
+            "Teleport",
+            "%attack% +1",
+            "%range% 5",
+            "%poison%",
+            "%wound%",
+            "%stun%"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "25xC",
+          "move": 2,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%move% +9",
+            "%attack% +9"
+          ],
+          "special2": [
+            "Teleport",
+            "%attack% +1",
+            "%range% 5",
+            "%poison%",
+            "%wound%",
+            "%stun%"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "29xC",
+          "move": 2,
+          "attack": 6,
+          "range": 0,
+          "special1": [
+            "%move% +9",
+            "%attack% +9"
+          ],
+          "special2": [
+            "Teleport",
+            "%attack% +1",
+            "%range% 5",
+            "%poison%",
+            "%wound%",
+            "%stun%"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "35xC",
+          "move": 2,
+          "attack": 6,
+          "range": 0,
+          "special1": [
+            "%move% +9",
+            "%attack% +9"
+          ],
+          "special2": [
+            "Teleport",
+            "%attack% +1",
+            "%range% 5",
+            "%poison%",
+            "%wound%",
+            "%stun%"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "39xC",
+          "move": 3,
+          "attack": 7,
+          "range": 0,
+          "special1": [
+            "%move% +9",
+            "%attack% +9"
+          ],
+          "special2": [
+            "Teleport",
+            "%attack% +1",
+            "%range% 5",
+            "%poison%",
+            "%wound%",
+            "%stun%"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "46xC",
+          "move": 3,
+          "attack": 7,
+          "range": 0,
+          "special1": [
+            "%move% +9",
+            "%attack% +9"
+          ],
+          "special2": [
+            "Teleport",
+            "%attack% +1",
+            "%range% 5",
+            "%poison%",
+            "%wound%",
+            "%stun%"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "50xC",
+          "move": 3,
+          "attack": 8,
+          "range": 0,
+          "special1": [
+            "%move% +9",
+            "%attack% +9"
+          ],
+          "special2": [
+            "Teleport",
+            "%attack% +1",
+            "%range% 5",
+            "%poison%",
+            "%wound%",
+            "%stun%"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "56xC",
+          "move": 3,
+          "attack": 9,
+          "range": 0,
+          "special1": [
+            "%move% +9",
+            "%attack% +9"
+          ],
+          "special2": [
+            "Teleport",
+            "%attack% +1",
+            "%range% 5",
+            "%poison%",
+            "%wound%",
+            "%stun%"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    "Inox Bodyguard": {
+      "level": [
+        {
+          "level": 0,
+          "health": "6xC",
+          "move": 2,
+          "attack": "C",
+          "range": 0,
+          "special1": [
+            "%move% -1",
+            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+          ],
+          "special2": [
+            "%move% +0",
+            "%attack% +0",
+            "%retaliate% 3"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "7xC",
+          "move": 2,
+          "attack": "1+C",
+          "range": 0,
+          "special1": [
+            "%move% -1",
+            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+          ],
+          "special2": [
+            "%move% +0",
+            "%attack% +0",
+            "%retaliate% 3"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "9xC",
+          "move": 2,
+          "attack": "1+C",
+          "range": 0,
+          "special1": [
+            "%move% -1",
+            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+          ],
+          "special2": [
+            "%move% +0",
+            "%attack% +0",
+            "%retaliate% 3"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "10xC",
+          "move": 3,
+          "attack": "2+C",
+          "range": 0,
+          "special1": [
+            "%move% -1",
+            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+          ],
+          "special2": [
+            "%move% +0",
+            "%attack% +0",
+            "%retaliate% 4"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "11xC",
+          "move": 3,
+          "attack": "2+C",
+          "range": 0,
+          "special1": [
+            "%move% -1",
+            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+          ],
+          "special2": [
+            "%move% +0",
+            "%attack% +0",
+            "%retaliate% 4"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "13xC",
+          "move": 3,
+          "attack": "3+C",
+          "range": 0,
+          "special1": [
+            "%move% -1",
+            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+          ],
+          "special2": [
+            "%move% +0",
+            "%attack% +0",
+            "%retaliate% 5"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "15xC",
+          "move": 4,
+          "attack": "3+C",
+          "range": 0,
+          "special1": [
+            "%move% -1",
+            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+          ],
+          "special2": [
+            "%move% +0",
+            "%attack% +0",
+            "%retaliate% 5"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "17xC",
+          "move": 4,
+          "attack": "4+C",
+          "range": 0,
+          "special1": [
+            "%move% -1",
+            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+          ],
+          "special2": [
+            "%move% +0",
+            "%attack% +0",
+            "%retaliate% 5"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    "Jekserah": {
+      "level": [
+        {
+          "level": 0,
+          "health": "6xC",
+          "move": 2,
+          "attack": 2,
+          "range": 0,
+          "special1": [
+            "Summon Living Bones",
+            "%attack% -1, Target all adjacent enemies"
+          ],
+          "special2": [
+            "Summon Living Corpse",
+            "%move% -1",
+            "%attack% +2"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "7xC",
+          "move": 2,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "Summon Living Bones",
+            "%attack% -1, Target all adjacent enemies"
+          ],
+          "special2": [
+            "Summon Living Corpse",
+            "%move% -1",
+            "%attack% +2"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "9xC",
+          "move": 3,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "Summon Living Bones",
+            "%attack% -1, Target all adjacent enemies"
+          ],
+          "special2": [
+            "Summon Living Corpse",
+            "%move% -1",
+            "%attack% +2"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "12xC",
+          "move": 4,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "Summon Living Bones",
+            "%attack% -1, Target all adjacent enemies"
+          ],
+          "special2": [
+            "Summon Living Corpse",
+            "%move% -1",
+            "%attack% +2"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "13xC",
+          "move": 4,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "Summon Living Bones",
+            "%attack% -1, Target all adjacent enemies"
+          ],
+          "special2": [
+            "Summon Living Corpse",
+            "%move% -1",
+            "%attack% +2"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "15xC",
+          "move": 5,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "Summon Living Bones",
+            "%attack% -1, Target all adjacent enemies"
+          ],
+          "special2": [
+            "Summon Living Corpse",
+            "%move% -1",
+            "%attack% +2"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "18xC",
+          "move": 5,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "Summon Living Bones",
+            "%attack% -1, Target all adjacent enemies"
+          ],
+          "special2": [
+            "Summon Living Corpse",
+            "%move% -1",
+            "%attack% +2"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "22xC",
+          "move": 5,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "Summon Living Bones",
+            "%attack% -1, Target all adjacent enemies"
+          ],
+          "special2": [
+            "Summon Living Corpse",
+            "%move% -1",
+            "%attack% +2"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    "Merciless Overseer": {
+      "level": [
+        {
+          "level": 0,
+          "health": "6xC",
+          "move": 2,
+          "attack": "V",
+          "range": 0,
+          "special1": [
+            "All Scouts act again"
+          ],
+          "special2": [
+            "Summon Vermling Scout"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": "V = Number of Scouts present"
+        },
+        {
+          "level": 1,
+          "health": "8xC",
+          "move": 2,
+          "attack": "V",
+          "range": 0,
+          "special1": [
+            "All Scouts act again"
+          ],
+          "special2": [
+            "Summon Vermling Scout"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": "V = Number of Scouts present"
+        },
+        {
+          "level": 2,
+          "health": "9xC",
+          "move": 3,
+          "attack": "V",
+          "range": 0,
+          "special1": [
+            "All Scouts act again"
+          ],
+          "special2": [
+            "Summon Vermling Scout"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": "V = Number of Scouts present"
+        },
+        {
+          "level": 3,
+          "health": "11xC",
+          "move": 3,
+          "attack": "V",
+          "range": 0,
+          "special1": [
+            "All Scouts act again"
+          ],
+          "special2": [
+            "Summon Vermling Scout"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": "V = Number of Scouts present"
+        },
+        {
+          "level": 4,
+          "health": "12xC",
+          "move": 4,
+          "attack": "V",
+          "range": 0,
+          "special1": [
+            "All Scouts act again"
+          ],
+          "special2": [
+            "Summon Vermling Scout"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": "V = Number of Scouts present"
+        },
+        {
+          "level": 5,
+          "health": "14xC",
+          "move": 4,
+          "attack": "V",
+          "range": 0,
+          "special1": [
+            "All Scouts act again"
+          ],
+          "special2": [
+            "Summon Vermling Scout"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": "V = Number of Scouts present"
+        },
+        {
+          "level": 6,
+          "health": "16xC",
+          "move": 4,
+          "attack": "V",
+          "range": 0,
+          "special1": [
+            "All Scouts act again"
+          ],
+          "special2": [
+            "Summon Vermling Scout"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": "V = Number of Scouts present"
+        },
+        {
+          "level": 7,
+          "health": "19xC",
+          "move": 4,
+          "attack": "V",
+          "range": 0,
+          "special1": [
+            "All Scouts act again"
+          ],
+          "special2": [
+            "Summon Vermling Scout"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%curse%",
+            "%stun%"
+          ],
+          "notes": "V = Number of Scouts present"
+        }
+      ]
+    },
+    "Prime Demon": {
+      "level": [
+        {
+          "level": 0,
+          "health": "8xC",
+          "move": 3,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "special2": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "9xC",
+          "move": 4,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "special2": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "10xC",
+          "move": 4,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "special2": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "12xC",
+          "move": 4,
+          "attack": 6,
+          "range": 0,
+          "special1": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "special2": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "14xC",
+          "move": 5,
+          "attack": 6,
+          "range": 0,
+          "special1": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "special2": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "16xC",
+          "move": 5,
+          "attack": 7,
+          "range": 0,
+          "special1": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "special2": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "20xC",
+          "move": 5,
+          "attack": 7,
+          "range": 0,
+          "special1": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "special2": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "22xC",
+          "move": 5,
+          "attack": 8,
+          "range": 0,
+          "special1": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "special2": [
+            "Throne moves",
+            "Summon Demon",
+            "%move% +2",
+            "%attack% -1"
+          ],
+          "immunities": [
+            "%wound%",
+            "%poison%",
+            "%disarm%",
+            "%immobilize%",
+            "%muddle%",
+            "%stun%"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    "The Sightless Eye": {
+      "level": [
+        {
+          "level": 0,
+          "health": "7xC",
+          "move": 0,
+          "attack": 5,
+          "range": 3,
+          "special1": [
+            "Summon Deep Terror",
+            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+          ],
+          "special2": [
+            "Summon Deep Terror",
+            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+          ],
+          "immunities": [
+            "%stun%",
+            "%disarm%",
+            "%curse%",
+            "%muddle%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "8xC",
+          "move": 0,
+          "attack": 6,
+          "range": 3,
+          "special1": [
+            "Summon Deep Terror",
+            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+          ],
+          "special2": [
+            "Summon Deep Terror",
+            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+          ],
+          "immunities": [
+            "%stun%",
+            "%disarm%",
+            "%curse%",
+            "%muddle%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "10xC",
+          "move": 0,
+          "attack": 6,
+          "range": 3,
+          "special1": [
+            "Summon Deep Terror",
+            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+          ],
+          "special2": [
+            "Summon Deep Terror",
+            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+          ],
+          "immunities": [
+            "%stun%",
+            "%disarm%",
+            "%curse%",
+            "%muddle%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "11xC",
+          "move": 0,
+          "attack": 7,
+          "range": 3,
+          "special1": [
+            "Summon Deep Terror",
+            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+          ],
+          "special2": [
+            "Summon Deep Terror",
+            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+          ],
+          "immunities": [
+            "%stun%",
+            "%disarm%",
+            "%curse%",
+            "%muddle%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "14xC",
+          "move": 0,
+          "attack": 7,
+          "range": 3,
+          "special1": [
+            "Summon Deep Terror",
+            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+          ],
+          "special2": [
+            "Summon Deep Terror",
+            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+          ],
+          "immunities": [
+            "%stun%",
+            "%disarm%",
+            "%curse%",
+            "%muddle%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "15xC",
+          "move": 0,
+          "attack": 8,
+          "range": 3,
+          "special1": [
+            "Summon Deep Terror",
+            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+          ],
+          "special2": [
+            "Summon Deep Terror",
+            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+          ],
+          "immunities": [
+            "%stun%",
+            "%disarm%",
+            "%curse%",
+            "%muddle%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "18xC",
+          "move": 0,
+          "attack": 8,
+          "range": 3,
+          "special1": [
+            "Summon Deep Terror",
+            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+          ],
+          "special2": [
+            "Summon Deep Terror",
+            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+          ],
+          "immunities": [
+            "%stun%",
+            "%disarm%",
+            "%curse%",
+            "%muddle%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "20xC",
+          "move": 0,
+          "attack": 9,
+          "range": 3,
+          "special1": [
+            "Summon Deep Terror",
+            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+          ],
+          "special2": [
+            "Summon Deep Terror",
+            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+          ],
+          "immunities": [
+            "%stun%",
+            "%disarm%",
+            "%curse%",
+            "%muddle%"
+          ],
+          "notes": ""
+        }
+      ]
+    },
+    "Winged Horror": {
+      "level": [
+        {
+          "level": 0,
+          "health": "6xC",
+          "move": 3,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "%attack% -1, Target all adjacent enemies",
+            "%attack% +0, %range% 3",
+            "Hatch eggs"
+          ],
+          "special2": [
+            "Summon C eggs",
+            "%move% -1",
+            "%attack% +0"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 1,
+          "health": "7xC",
+          "move": 4,
+          "attack": 3,
+          "range": 0,
+          "special1": [
+            "%attack% -1, Target all adjacent enemies",
+            "%attack% +0, %range% 3",
+            "Hatch eggs"
+          ],
+          "special2": [
+            "Summon C eggs",
+            "%move% -1",
+            "%attack% +0"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 2,
+          "health": "8xC",
+          "move": 4,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%attack% -1, Target all adjacent enemies",
+            "%attack% +0, %range% 3",
+            "Hatch eggs"
+          ],
+          "special2": [
+            "Summon C eggs",
+            "%move% -1",
+            "%attack% +0"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 3,
+          "health": "10xC",
+          "move": 4,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%attack% -1, Target all adjacent enemies",
+            "%attack% +0, %range% 3",
+            "Hatch eggs"
+          ],
+          "special2": [
+            "Summon C eggs",
+            "%move% -1",
+            "%attack% +0"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 4,
+          "health": "12xC",
+          "move": 5,
+          "attack": 4,
+          "range": 0,
+          "special1": [
+            "%attack% -1, Target all adjacent enemies",
+            "%attack% +0, %range% 3",
+            "Hatch eggs"
+          ],
+          "special2": [
+            "Summon C eggs",
+            "%move% -1",
+            "%attack% +0"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 5,
+          "health": "14xC",
+          "move": 5,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%attack% -1, Target all adjacent enemies",
+            "%attack% +0, %range% 3",
+            "Hatch eggs"
+          ],
+          "special2": [
+            "Summon C eggs",
+            "%move% -1",
+            "%attack% +0"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 6,
+          "health": "17xC",
+          "move": 5,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%attack% -1, Target all adjacent enemies",
+            "%attack% +0, %range% 3",
+            "Hatch eggs"
+          ],
+          "special2": [
+            "Summon C eggs",
+            "%move% -1",
+            "%attack% +0"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        },
+        {
+          "level": 7,
+          "health": "20xC",
+          "move": 5,
+          "attack": 5,
+          "range": 0,
+          "special1": [
+            "%attack% -1, Target all adjacent enemies",
+            "%attack% +0, %range% 3",
+            "Hatch eggs"
+          ],
+          "special2": [
+            "Summon C eggs",
+            "%move% -1",
+            "%attack% +0"
+          ],
+          "immunities": [
+            "%disarm%",
+            "%poison%",
+            "%muddle%",
+            "%stun%",
+            "%curse%"
+          ],
+          "notes": ""
+        }
+      ]
+    }
+  }
+};

--- a/monster_stats.js
+++ b/monster_stats.js
@@ -1,4 +1,4 @@
-SPECIAL_VALUES = 
+SPECIAL_VALUES =
 {
   "X": "X = Hexes moved",
   "C": "C = Number of Characters",
@@ -541,7 +541,7 @@ MONSTER_STATS = {
             "attack": 3,
             "range": 4,
             "attributes": [
-              "%attack%ers gain Disadvantage",
+              "Attackers gain Disadvantage",
               "%poison%"
             ]
           }
@@ -563,7 +563,7 @@ MONSTER_STATS = {
             "attack": 3,
             "range": 4,
             "attributes": [
-              "%attack%ers gain Disadvantage",
+              "Attackers gain Disadvantage",
               "%poison%"
             ]
           }
@@ -585,7 +585,7 @@ MONSTER_STATS = {
             "attack": 3,
             "range": 5,
             "attributes": [
-              "%attack%ers gain Disadvantage",
+              "Attackers gain Disadvantage",
               "%poison%"
             ]
           }
@@ -607,7 +607,7 @@ MONSTER_STATS = {
             "attack": 4,
             "range": 5,
             "attributes": [
-              "%attack%ers gain Disadvantage",
+              "Attackers gain Disadvantage",
               "%poison%"
             ]
           }
@@ -629,7 +629,7 @@ MONSTER_STATS = {
             "attack": 4,
             "range": 5,
             "attributes": [
-              "%attack%ers gain Disadvantage",
+              "Attackers gain Disadvantage",
               "%poison%"
             ]
           }
@@ -1650,7 +1650,7 @@ MONSTER_STATS = {
             "range": 3,
             "attributes": [
               "Flying",
-              "Sheild 3"
+              "%shield% 3"
             ]
           },
           "elite": {
@@ -1660,7 +1660,7 @@ MONSTER_STATS = {
             "range": 4,
             "attributes": [
               "Flying",
-              "%retaliate% 2, %range% 2",
+              "%retaliate% 2: %range% 2",
               "%shield% 4"
             ]
           }
@@ -1684,7 +1684,7 @@ MONSTER_STATS = {
             "range": 4,
             "attributes": [
               "Flying",
-              "%retaliate% 3, %range% 2",
+              "%retaliate% 3: %range% 2",
               "%shield% 4"
             ]
           }
@@ -1698,7 +1698,7 @@ MONSTER_STATS = {
             "range": 4,
             "attributes": [
               "Flying",
-              "%retaliate% 2, %range% 2",
+              "%retaliate% 2: %range% 2",
               "%shield% 3"
             ]
           },
@@ -1709,7 +1709,7 @@ MONSTER_STATS = {
             "range": 5,
             "attributes": [
               "Flying",
-              "%retaliate% 3, %range% 3",
+              "%retaliate% 3: %range% 3",
               "%shield% 4"
             ]
           }
@@ -1723,7 +1723,7 @@ MONSTER_STATS = {
             "range": 4,
             "attributes": [
               "Flying",
-              "%retaliate% 3, %range% 2",
+              "%retaliate% 3: %range% 2",
               "%shield% 3"
             ]
           },
@@ -1734,7 +1734,7 @@ MONSTER_STATS = {
             "range": 5,
             "attributes": [
               "Flying",
-              "%retaliate% 4, %range% 3",
+              "%retaliate% 4: %range% 3",
               "%shield% 4"
             ]
           }
@@ -1748,7 +1748,7 @@ MONSTER_STATS = {
             "range": 4,
             "attributes": [
               "Flying",
-              "%retaliate% 3, %range% 2",
+              "%retaliate% 3: %range% 2",
               "%shield% 4"
             ]
           },
@@ -1759,7 +1759,7 @@ MONSTER_STATS = {
             "range": 5,
             "attributes": [
               "Flying",
-              "%retaliate% 4, %range% 3",
+              "%retaliate% 4: %range% 3",
               "%shield% 5"
             ]
           }
@@ -1773,7 +1773,7 @@ MONSTER_STATS = {
             "range": 4,
             "attributes": [
               "Flying",
-              "%retaliate% 4, %range% 2",
+              "%retaliate% 4: %range% 2",
               "%shield% 4"
             ]
           },
@@ -1784,7 +1784,7 @@ MONSTER_STATS = {
             "range": 5,
             "attributes": [
               "Flying",
-              "%retaliate% 5, %range% 3",
+              "%retaliate% 5: %range% 3",
               "%shield% 5"
             ]
           }
@@ -1798,7 +1798,7 @@ MONSTER_STATS = {
             "range": 5,
             "attributes": [
               "Flying",
-              "%retaliate% 4, %range% 3",
+              "%retaliate% 4: %range% 3",
               "%shield% 4"
             ]
           },
@@ -1809,7 +1809,7 @@ MONSTER_STATS = {
             "range": 6,
             "attributes": [
               "Flying",
-              "%retaliate% 5, %range% 4",
+              "%retaliate% 5: %range% 4",
               "%shield% 5"
             ]
           }
@@ -4023,7 +4023,7 @@ MONSTER_STATS = {
             "attack": 3,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           },
           "elite": {
@@ -4032,7 +4032,7 @@ MONSTER_STATS = {
             "attack": 4,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           }
         },
@@ -4044,7 +4044,7 @@ MONSTER_STATS = {
             "attack": 3,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           },
           "elite": {
@@ -4053,7 +4053,7 @@ MONSTER_STATS = {
             "attack": 4,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           }
         },
@@ -4065,7 +4065,7 @@ MONSTER_STATS = {
             "attack": 4,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           },
           "elite": {
@@ -4074,7 +4074,7 @@ MONSTER_STATS = {
             "attack": 4,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           }
         },
@@ -4086,7 +4086,7 @@ MONSTER_STATS = {
             "attack": 4,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           },
           "elite": {
@@ -4095,7 +4095,7 @@ MONSTER_STATS = {
             "attack": 5,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           }
         },
@@ -4107,7 +4107,7 @@ MONSTER_STATS = {
             "attack": 5,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           },
           "elite": {
@@ -4116,7 +4116,7 @@ MONSTER_STATS = {
             "attack": 5,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           }
         },
@@ -4128,7 +4128,7 @@ MONSTER_STATS = {
             "attack": 5,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           },
           "elite": {
@@ -4137,7 +4137,7 @@ MONSTER_STATS = {
             "attack": 6,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           }
         },
@@ -4149,7 +4149,7 @@ MONSTER_STATS = {
             "attack": 5,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           },
           "elite": {
@@ -4158,7 +4158,7 @@ MONSTER_STATS = {
             "attack": 6,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           }
         },
@@ -4170,7 +4170,7 @@ MONSTER_STATS = {
             "attack": 6,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           },
           "elite": {
@@ -4179,7 +4179,7 @@ MONSTER_STATS = {
             "attack": 8,
             "range": 0,
             "attributes": [
-              "%attack%ers gain Disadvantage"
+              "Attackers gain Disadvantage"
             ]
           }
         }
@@ -5745,7 +5745,7 @@ MONSTER_STATS = {
           "attack": 3,
           "range": 0,
           "special1": [
-            "%move% to next door and reveal room"
+            "Move to next door and reveal room"
           ],
           "special2": [
             "Summon Living Bones"
@@ -5764,7 +5764,7 @@ MONSTER_STATS = {
           "attack": 3,
           "range": 0,
           "special1": [
-            "%move% to next door and reveal room"
+            "Move to next door and reveal room"
           ],
           "special2": [
             "Summon Living Bones"
@@ -5783,7 +5783,7 @@ MONSTER_STATS = {
           "attack": 3,
           "range": 0,
           "special1": [
-            "%move% to next door and reveal room"
+            "Move to next door and reveal room"
           ],
           "special2": [
             "Summon Living Bones"
@@ -5802,7 +5802,7 @@ MONSTER_STATS = {
           "attack": 4,
           "range": 0,
           "special1": [
-            "%move% to next door and reveal room"
+            "Move to next door and reveal room"
           ],
           "special2": [
             "Summon Living Bones"
@@ -5821,7 +5821,7 @@ MONSTER_STATS = {
           "attack": 4,
           "range": 0,
           "special1": [
-            "%move% to next door and reveal room"
+            "Move to next door and reveal room"
           ],
           "special2": [
             "Summon Living Bones"
@@ -5840,7 +5840,7 @@ MONSTER_STATS = {
           "attack": 5,
           "range": 0,
           "special1": [
-            "%move% to next door and reveal room"
+            "Move to next door and reveal room"
           ],
           "special2": [
             "Summon Living Bones"
@@ -5859,7 +5859,7 @@ MONSTER_STATS = {
           "attack": 5,
           "range": 0,
           "special1": [
-            "%move% to next door and reveal room"
+            "Move to next door and reveal room"
           ],
           "special2": [
             "Summon Living Bones"
@@ -5878,7 +5878,7 @@ MONSTER_STATS = {
           "attack": 5,
           "range": 0,
           "special1": [
-            "%move% to next door and reveal room"
+            "Move to next door and reveal room"
           ],
           "special2": [
             "Summon Living Bones"
@@ -6100,7 +6100,12 @@ MONSTER_STATS = {
             "All allies add +1 Attack to all attacks this round",
             "%attack% +1"
           ],
-          "immunities": [],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%muddle%",
+            "%stun%"
+          ],
           "notes": ""
         },
         {
@@ -6116,7 +6121,12 @@ MONSTER_STATS = {
             "All allies add +1 Attack to all attacks this round",
             "%attack% +1"
           ],
-          "immunities": [],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%muddle%",
+            "%stun%"
+          ],
           "notes": ""
         },
         {
@@ -6132,7 +6142,12 @@ MONSTER_STATS = {
             "All allies add +1 Attack to all attacks this round",
             "%attack% +1"
           ],
-          "immunities": [],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%muddle%",
+            "%stun%"
+          ],
           "notes": ""
         },
         {
@@ -6148,7 +6163,12 @@ MONSTER_STATS = {
             "All allies add +1 Attack to all attacks this round",
             "%attack% +1"
           ],
-          "immunities": [],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%muddle%",
+            "%stun%"
+          ],
           "notes": ""
         },
         {
@@ -6164,7 +6184,12 @@ MONSTER_STATS = {
             "All allies add +1 Attack to all attacks this round",
             "%attack% +1"
           ],
-          "immunities": [],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%muddle%",
+            "%stun%"
+          ],
           "notes": ""
         },
         {
@@ -6180,7 +6205,12 @@ MONSTER_STATS = {
             "All allies add +1 Attack to all attacks this round",
             "%attack% +1"
           ],
-          "immunities": [],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%muddle%",
+            "%stun%"
+          ],
           "notes": ""
         },
         {
@@ -6196,7 +6226,12 @@ MONSTER_STATS = {
             "All allies add +1 Attack to all attacks this round",
             "%attack% +1"
           ],
-          "immunities": [],
+          "immunities": [
+            "%disarm%",
+            "%wound%",
+            "%muddle%",
+            "%stun%"
+          ],
           "notes": ""
         }
       ]
@@ -6594,7 +6629,7 @@ MONSTER_STATS = {
           "attack": 3,
           "range": 0,
           "special1": [
-            "%attack% +0 {{resources.elderDrake.special1Area}}"
+            "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
             "%move% and summon 2 Zephyrs"
@@ -6615,7 +6650,7 @@ MONSTER_STATS = {
           "attack": 4,
           "range": 0,
           "special1": [
-            "%attack% +0 {{resources.elderDrake.special1Area}}"
+            "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
             "%move% and summon 2 Zephyrs"
@@ -6636,7 +6671,7 @@ MONSTER_STATS = {
           "attack": 4,
           "range": 0,
           "special1": [
-            "%attack% +0 {{resources.elderDrake.special1Area}}"
+            "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
             "%move% and summon 2 Zephyrs"
@@ -6657,7 +6692,7 @@ MONSTER_STATS = {
           "attack": 5,
           "range": 0,
           "special1": [
-            "%attack% +0 {{resources.elderDrake.special1Area}}"
+            "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
             "%move% and summon 2 Zephyrs"
@@ -6678,7 +6713,7 @@ MONSTER_STATS = {
           "attack": 5,
           "range": 0,
           "special1": [
-            "%attack% +0 {{resources.elderDrake.special1Area}}"
+            "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
             "%move% and summon 2 Zephyrs"
@@ -6699,7 +6734,7 @@ MONSTER_STATS = {
           "attack": 6,
           "range": 0,
           "special1": [
-            "%attack% +0 {{resources.elderDrake.special1Area}}"
+            "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
             "%move% and summon 2 Zephyrs"
@@ -6720,7 +6755,7 @@ MONSTER_STATS = {
           "attack": 6,
           "range": 0,
           "special1": [
-            "%attack% +0 {{resources.elderDrake.special1Area}}"
+            "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
             "%move% and summon 2 Zephyrs"
@@ -6741,7 +6776,7 @@ MONSTER_STATS = {
           "attack": 7,
           "range": 0,
           "special1": [
-            "%attack% +0 {{resources.elderDrake.special1Area}}"
+            "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
             "%move% and summon 2 Zephyrs"
@@ -7003,7 +7038,7 @@ MONSTER_STATS = {
           "range": 0,
           "special1": [
             "%move% -1",
-            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+            "%attack% -1 %boss-aoe-inox-bodyguard-sp1%"
           ],
           "special2": [
             "%move% +0",
@@ -7026,7 +7061,7 @@ MONSTER_STATS = {
           "range": 0,
           "special1": [
             "%move% -1",
-            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+            "%attack% -1 %boss-aoe-inox-bodyguard-sp1%"
           ],
           "special2": [
             "%move% +0",
@@ -7049,7 +7084,7 @@ MONSTER_STATS = {
           "range": 0,
           "special1": [
             "%move% -1",
-            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+            "%attack% -1 %boss-aoe-inox-bodyguard-sp1%"
           ],
           "special2": [
             "%move% +0",
@@ -7072,7 +7107,7 @@ MONSTER_STATS = {
           "range": 0,
           "special1": [
             "%move% -1",
-            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+            "%attack% -1 %boss-aoe-inox-bodyguard-sp1%"
           ],
           "special2": [
             "%move% +0",
@@ -7095,7 +7130,7 @@ MONSTER_STATS = {
           "range": 0,
           "special1": [
             "%move% -1",
-            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+            "%attack% -1 %boss-aoe-inox-bodyguard-sp1%"
           ],
           "special2": [
             "%move% +0",
@@ -7118,7 +7153,7 @@ MONSTER_STATS = {
           "range": 0,
           "special1": [
             "%move% -1",
-            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+            "%attack% -1 %boss-aoe-inox-bodyguard-sp1%"
           ],
           "special2": [
             "%move% +0",
@@ -7141,7 +7176,7 @@ MONSTER_STATS = {
           "range": 0,
           "special1": [
             "%move% -1",
-            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+            "%attack% -1 %boss-aoe-inox-bodyguard-sp1%"
           ],
           "special2": [
             "%move% +0",
@@ -7164,7 +7199,7 @@ MONSTER_STATS = {
           "range": 0,
           "special1": [
             "%move% -1",
-            "%attack% -1 {{resources.inoxBodyguard.special1Area}}"
+            "%attack% -1 %boss-aoe-inox-bodyguard-sp1%"
           ],
           "special2": [
             "%move% +0",
@@ -7771,11 +7806,11 @@ MONSTER_STATS = {
           "range": 3,
           "special1": [
             "Summon Deep Terror",
-            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+            "%attack% -3 %boss-aoe-sightless-eye-sp1%"
           ],
           "special2": [
             "Summon Deep Terror",
-            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+            "%attack% -2 %boss-aoe-sightless-eye-sp2%"
           ],
           "immunities": [
             "%stun%",
@@ -7793,11 +7828,11 @@ MONSTER_STATS = {
           "range": 3,
           "special1": [
             "Summon Deep Terror",
-            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+            "%attack% -3 %boss-aoe-sightless-eye-sp1%"
           ],
           "special2": [
             "Summon Deep Terror",
-            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+            "%attack% -2 %boss-aoe-sightless-eye-sp2%"
           ],
           "immunities": [
             "%stun%",
@@ -7815,11 +7850,11 @@ MONSTER_STATS = {
           "range": 3,
           "special1": [
             "Summon Deep Terror",
-            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+            "%attack% -3 %boss-aoe-sightless-eye-sp1%"
           ],
           "special2": [
             "Summon Deep Terror",
-            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+            "%attack% -2 %boss-aoe-sightless-eye-sp2%"
           ],
           "immunities": [
             "%stun%",
@@ -7837,11 +7872,11 @@ MONSTER_STATS = {
           "range": 3,
           "special1": [
             "Summon Deep Terror",
-            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+            "%attack% -3 %boss-aoe-sightless-eye-sp1%"
           ],
           "special2": [
             "Summon Deep Terror",
-            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+            "%attack% -2 %boss-aoe-sightless-eye-sp2%"
           ],
           "immunities": [
             "%stun%",
@@ -7859,11 +7894,11 @@ MONSTER_STATS = {
           "range": 3,
           "special1": [
             "Summon Deep Terror",
-            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+            "%attack% -3 %boss-aoe-sightless-eye-sp1%"
           ],
           "special2": [
             "Summon Deep Terror",
-            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+            "%attack% -2 %boss-aoe-sightless-eye-sp2%"
           ],
           "immunities": [
             "%stun%",
@@ -7881,11 +7916,11 @@ MONSTER_STATS = {
           "range": 3,
           "special1": [
             "Summon Deep Terror",
-            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+            "%attack% -3 %boss-aoe-sightless-eye-sp1%"
           ],
           "special2": [
             "Summon Deep Terror",
-            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+            "%attack% -2 %boss-aoe-sightless-eye-sp2%"
           ],
           "immunities": [
             "%stun%",
@@ -7903,11 +7938,11 @@ MONSTER_STATS = {
           "range": 3,
           "special1": [
             "Summon Deep Terror",
-            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+            "%attack% -3 %boss-aoe-sightless-eye-sp1%"
           ],
           "special2": [
             "Summon Deep Terror",
-            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+            "%attack% -2 %boss-aoe-sightless-eye-sp2%"
           ],
           "immunities": [
             "%stun%",
@@ -7925,11 +7960,11 @@ MONSTER_STATS = {
           "range": 3,
           "special1": [
             "Summon Deep Terror",
-            "%attack% -3 {{resources.sightlessEye.special1Area}}"
+            "%attack% -3 %boss-aoe-sightless-eye-sp1%"
           ],
           "special2": [
             "Summon Deep Terror",
-            "%attack% -2 {{resources.sightlessEye.special2Area}}"
+            "%attack% -2 %boss-aoe-sightless-eye-sp2%"
           ],
           "immunities": [
             "%stun%",

--- a/monster_stats.js
+++ b/monster_stats.js
@@ -1,3 +1,10 @@
+SPECIAL_VALUES = 
+{
+  "X": "X = Hexes moved",
+  "C": "C = Number of Characters",
+  "V": "V = Number of Scouts present"
+}
+
 MONSTER_STATS = {
   "monsters": {
     "Ancient Artillery": {
@@ -7009,7 +7016,7 @@ MONSTER_STATS = {
             "%muddle%",
             "%stun%"
           ],
-          "notes": ""
+          "notes": "C = Number of Characters"
         },
         {
           "level": 1,
@@ -7032,7 +7039,7 @@ MONSTER_STATS = {
             "%muddle%",
             "%stun%"
           ],
-          "notes": ""
+          "notes": "C = Number of Characters"
         },
         {
           "level": 2,
@@ -7055,7 +7062,7 @@ MONSTER_STATS = {
             "%muddle%",
             "%stun%"
           ],
-          "notes": ""
+          "notes": "C = Number of Characters"
         },
         {
           "level": 3,
@@ -7078,7 +7085,7 @@ MONSTER_STATS = {
             "%muddle%",
             "%stun%"
           ],
-          "notes": ""
+          "notes": "C = Number of Characters"
         },
         {
           "level": 4,
@@ -7101,7 +7108,7 @@ MONSTER_STATS = {
             "%muddle%",
             "%stun%"
           ],
-          "notes": ""
+          "notes": "C = Number of Characters"
         },
         {
           "level": 5,
@@ -7124,7 +7131,7 @@ MONSTER_STATS = {
             "%muddle%",
             "%stun%"
           ],
-          "notes": ""
+          "notes": "C = Number of Characters"
         },
         {
           "level": 6,
@@ -7147,7 +7154,7 @@ MONSTER_STATS = {
             "%muddle%",
             "%stun%"
           ],
-          "notes": ""
+          "notes": "C = Number of Characters"
         },
         {
           "level": 7,
@@ -7170,7 +7177,7 @@ MONSTER_STATS = {
             "%muddle%",
             "%stun%"
           ],
-          "notes": ""
+          "notes": "C = Number of Characters"
         }
       ]
     },

--- a/scenarios.js
+++ b/scenarios.js
@@ -1,4 +1,14 @@
 //special_rules should be treated with some kind of macro that recognises them and applies them when loading
+SPECIAL_RULES =
+{
+    living_corpse_two_levels_extra: 
+        {   "description": "All living corpses are two levels higher than the scenario level, up to a max of 7",
+            "affected_deck": "Living Corpse",
+            "extra_levels": 2
+        }
+};
+
+
 SCENARIO_DEFINITIONS =
     [   { name: "#1 Black Barrow"
         , decks:
@@ -228,6 +238,9 @@ SCENARIO_DEFINITIONS =
             ,   {"name": "Night Demon", "deck_name": "Night Demon" }
             ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
             ]
+        , special_rules:
+            [ SPECIAL_RULES.living_corpse_two_levels_extra
+            ]
         },
         { name: "#29 Sanctuary of Gloom"
         , decks:
@@ -267,9 +280,6 @@ SCENARIO_DEFINITIONS =
             ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
             ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
             ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ]
-        , special_rules:
-            [ "All living corpses are two levels higher than the scenario level, up to a max of 7"
             ]
         },
         { name: "#34 Scorched Summit"
@@ -386,7 +396,7 @@ SCENARIO_DEFINITIONS =
         },
         { name: "#48 - Shadow Weald"
         , decks:
-            [   {"name": "Imp", "deck_name": "Imp" }
+            [   {"name": "Forest Imp", "deck_name": "Imp" }
             ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
             ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
             ,   {"name": "Boss: Dark Rider", "deck_name": "Boss" }

--- a/scenarios.js
+++ b/scenarios.js
@@ -1,438 +1,441 @@
+//special_rules should be treated with some kind of macro that recognises them and applies them when loading
 SCENARIO_DEFINITIONS =
     [   { name: "#1 Black Barrow"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Living Bones" ]
+            [   {"name": "Bandit Guard", "deck_name": "Guard"}
+            ,   {"name": "Bandit Archer", "deck_name": "Archer"}
+            ,   {"name": "Living Bones", "deck_name": "Living Bones"}
+            ]
         },
         { name: "#2 Barrow Lair"
         , decks:
-            [ "Archer"
-            , "Boss"
-            , "Living Bones"
-            , "Living Corpse"
+            [   {"name": "Bandit Archer", "deck_name": "Archer" }
+            ,   {"name": "Boss: Bandit Commander", "deck_name": "Boss" }
+            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
             ]
         },
         { name: "#3 Inox Encampment"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Shaman" ]
+            [   {"name": "Inox Guard", "deck_name": "Guard" }
+            ,   {"name": "Inox Archer", "deck_name": "Archer" }
+            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
+            ]
         },
         { name: "#4 Crypt of the Damned"
         , decks:
-            [ "Living Bones"
-            , "Archer"
-            , "Cultist"
-            , "Earth Demon"
-            , "Wind Demon"
+            [   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Bandit Archer", "deck_name": "Archer" }
+            ,   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
             ]
         },
         { name: "#5 Ruinous Crypt"
         , decks:
-            [ "Cultist"
-            , "Living Bones"
-            , "Living Corpse"
-            , "Night Demon"
-            , "Flame Demon"
-            , "Frost Demon"
+            [   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
             ]
         },
         { name: "#6 Decaying Crypt"
         , decks:
-            [ "Living Bones"
-            , "Living Corpse"
-            , "Living Spirit"
+            [   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#7 Vibrant Grotto"
         , decks:
-            [ "Imp"
-            , "Cave Bear"
-            , "Shaman"
-            , "Earth Demon"
+            [   {"name": "Forest Imp", "deck_name": "Imp" }
+            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
             ]
         },
         { name: "#8 Gloomhaven Warehouse"
         , decks:
-            [ "Living Bones"
-            , "Living Corpse"
-            , "Boss"
+            [   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Boss: Inox Bodyguard", "deck_name": "Boss" }
             ]
         },
         { name: "#9 Diamond Mine"
         , decks:
-            [ "Hound"
-            , "Scout"
-            , "Boss"
+            [   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Vermling Scout", "deck_name": "Scout" }
+            ,   {"name": "Boss: Merciless Overseer", "deck_name": "Boss" }
             ]
         },
         { name: "#10 Plane of Elemental Power"
         , decks:
-            [ "Flame Demon"
-            , "Earth Demon"
-            , "Sun Demon"
+            [   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
             ]
         },
         { name: "#11 Gloomhaven Square A"
         , decks:
-            [ "Living Bones"
-            , "Living Corpse"
-            , "Guard"
-            , "Archer"
-            , "Boss"
+            [   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "City Guard", "deck_name": "Guard" }
+            ,   {"name": "City Archer", "deck_name": "Archer" }
+            ,   {"name": "Boss: Captain of the Guard", "deck_name": "Boss" }
             ]
         },
         { name: "#12 Gloomhaven Square B"
         , decks:
-            [ "Living Bones"
-            , "Living Corpse"
-            , "Cultist"
-            , "Guard"
-            , "Archer"
-            , "Boss"
+            [   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "City Guard", "deck_name": "Guard" }
+            ,   {"name": "City Archer", "deck_name": "Archer" }
+            ,   {"name": "Boss: Jekserah", "deck_name": "Boss" }
             ]
         },
         { name: "#13 Temple of the Seer"
         , decks:
-            [ "Stone Golem"
-            , "Cave Bear"
-            , "Living Spirit"
-            , "Spitting Drake"
+            [   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
             ]
         },
         { name: "#14 Frozen Hollow"
         , decks:
-            [ "Hound"
-            , "Living Spirit"
-            , "Frost Demon"
+            [   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
             ]
         },
         { name: "#15 Shrine of Strength"
         , decks:
-            [ "Stone Golem"
-            , "Savvas Icestorm"
-            , "Frost Demon"
-            , "Wind Demon"
-            , "Harrower Infester"
+            [   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            ,   {"name": "Savvas Icestorm", "deck_name": "Savvas Icestorm" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
             ]
         },
         { name: "#16 Mountain Pass"
         , decks:
-            [ "Earth Demon"
-            , "Wind Demon"
-            , "Guard"
-            , "Archer"
+            [   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "Inox Guard", "deck_name": "Guard" }
+            ,   {"name": "Inox Archer", "deck_name": "Archer" }
             ]
         },
         { name: "#17 Lost Island"
         , decks:
-            [ "Scout"
-            , "Shaman"
-            , "Cave Bear"
+            [   {"name": "Vermling Scout", "deck_name": "Scout" }
+            ,   {"name": "Vermling Shaman", "deck_name": "Shaman" }
+            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
             ]
         },
         { name: "#18 Abandoned Sewers"
         , decks:
-            [ "Giant Viper"
-            , "Ooze"
-            , "Scout"
+            [   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            ,   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Vermling Scout", "deck_name": "Scout" }
             ]
         },
         { name: "#19 Forgotten Crypt"
         , decks:
-            [ "Cultist"
-            , "Living Bones"
-            , "Living Spirit"
-            , "Living Corpse"
+            [   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
             ]
         },
         { name: "#20 Necromancer's Sanctum"
         , decks:
-            [ "Living Bones"
-            , "Cultist"
-            , "Night Demon"
-            , "Living Corpse"
-            , "Boss"
+            [   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Boss: Jekserah", "deck_name": "Boss" }
             ]
         },
         { name: "#21 Infernal Throne"
         , decks:
-            [ "Sun Demon"
-            , "Frost Demon"
-            , "Night Demon"
-            , "Wind Demon"
-            , "Earth Demon"
-            , "Flame Demon"
-            , "Boss"
+            [   {"name": "Sun Demon", "deck_name": "Sun Demon" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Boss: Prime Demon", "deck_name": "Boss" }
             ]
         },
         { name: "#22 Temple of the Elements"
         , decks:
-            [ "Living Bones"
-            , "Cultist"
-            , "Earth Demon"
-            , "Flame Demon"
-            , "Frost Demon"
-            , "Wind Demon"
+            [   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
             ]
         },
         { name: "#23 Deep Ruins"
         , decks:
-            [ "Stone Golem"
-            , "Ancient Artillery"
-            , "Living Bones"
-            , "Living Spirit"
+            [   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
+            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#24 Echo Chamber"
         , decks:
-            [ "Rending Drake"
-            , "Ooze"
-            , "Living Spirit"
+            [   {"name": "Rending Drake", "deck_name": "Rending Drake" }
+            ,   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#25 Icecrag Ascent"
         , decks:
-            [ "Hound"
-            , "Rending Drake"
-            , "Spitting Drake"
+            [   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Rending Drake", "deck_name": "Rending Drake" }
+            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
             ]
         },
         { name: "#26 Ancient Cistern"
         , decks:
-            [ "Living Corpse"
-            , "Ooze"
-            , "Night Demon"
-            , "Imp"
+            [   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Black Imp", "deck_name": "Imp" }
             ]
         },
         { name: "#27 Ruinous Rift"
         , decks:
-            [ "Night Demon"
-            , "Wind Demon"
-            , "Frost Demon"
-            , "Sun Demon"
-            , "Earth Demon"
-            , "Flame Demon"
+            [   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
             ]
         },
         { name: "#28 Outer Ritual Chamber"
         , decks:
-            [ "Living Corpse"
-            , "Cultist"
-            , "Living Bones"
-            , "Night Demon"
-            , "Sun Demon"
+            [   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
             ]
         },
         { name: "#29 Sanctuary of Gloom"
         , decks:
-            [ "Living Bones"
-            , "Living Corpse"
-            , "Living Spirit"
-            , "Imp"
+            [   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            ,   {"name": "Black Imp", "deck_name": "Imp" }
             ]
         },
         { name: "#30 Shrine of the Depths"
         , decks:
-            [ "Ooze"
-            , "Lurker"
-            , "Deep Terror"
+            [   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Lurker", "deck_name": "Lurker" }
+            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
             ]
         },
         { name: "#31 Plane of the Night"
         , decks:
-            [ "Deep Terror"
-            , "Night Demon"
-            , "Imp"
+            [   {"name": "Deep Terror", "deck_name": "Deep Terror" }
+            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Black Imp", "deck_name": "Imp" }
             ]
         },
         { name: "#32 Decrepit Wood"
         , decks:
-            [ "Harrower Infester"
-            , "Giant Viper"
-            , "Deep Terror"
-            , "Imp"
+            [   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
+            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
+            ,   {"name": "Black Imp", "deck_name": "Imp" }
             ]
         },
         { name: "#33 Savvas Armory"
         , decks:
-            [ "Savvas Icestorm"
-            , "Savvas Lavaflow"
-            , "Frost Demon"
-            , "Flame Demon"
-            , "Wind Demon"
-            , "Earth Demon"
+            [   {"name": "Savvas Icestorm", "deck_name": "Savvas Icestorm" }
+            ,   {"name": "Savvas Lavaflow", "deck_name": "Savvas Lavaflow" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ]
+        , special_rules:
+            [ "All living corpses are two levels higher than the scenario level, up to a max of 7"
             ]
         },
         { name: "#34 Scorched Summit"
         , decks:
-            [ "Rending Drake"
-            , "Spitting Drake"
-            , "Boss"
+            [   {"name": "Rending Drake", "deck_name": "Rending Drake" }
+            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
+            ,   {"name": "Boss: Elder Drake", "deck_name": "Boss" }
             ]
         },
         { name: "#35 Gloomhaven Battlements A"
         , decks:
-            [ "Flame Demon"
-            , "Frost Demon"
-            , "Earth Demon"
-            , "Wind Demon"
-            , "Guard"
-            , "Archer"
-            , "Boss"
+            [   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
             ]
         },
         { name: "#36 Gloomhaven Battlements B"
         , decks:
-            [ "Flame Demon"
-            , "Frost Demon"
-            , "Earth Demon"
-            , "Wind Demon"
-            , "Archer"
-            , "Boss"
+            [   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "City Archer", "deck_name": "Archer" }
+            ,   {"name": "Boss: Prime Demon", "deck_name": "Boss" }
             ]
         },
         { name: "#37 Doom Trench"
         , decks:
-            [ "Lurker"
-            , "Deep Terror"
-            , "Harrower Infester"
+            [   {"name": "Lurker", "deck_name": "Lurker" }
+            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
+            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
             ]
         },
         { name: "#38 Slave Pens"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Shaman"
-            , "Stone Golem"
+            [   {"name": "Inox Guard", "deck_name": "Guard" }
+            ,   {"name": "Inox Archer", "deck_name": "Archer" }
+            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
+            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
             ]
         },
         { name: "#39 Treacherous Divide"
         , decks:
-            [ "Cave Bear"
-            , "Frost Demon"
-            , "Spitting Drake"
-            , "Cultist"
-            , "Living Bones"
+            [   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
+            ,   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
             ]
         },
         { name: "#40 Ancient Defense Network"
         , decks:
-            [ "Living Corpse"
-            , "Flame Demon"
-            , "Cave Bear"
-            , "Stone Golem"
-            , "Imp"
+            [   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            ,   {"name": "Forest Imp", "deck_name": "Imp" }
             ]
         },
         { name: "#41 Timeworn Tomb"
         , decks:
-            [ "Ancient Artillery"
-            , "Living Corpse"
-            , "Living Spirit"
-            , "Stone Golem"
+            [   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
             ]
         },
         { name: "#42 Realm of the Voice"
         , decks:
-            [ "Night Demon"
-            , "Wind Demon"
-            , "Living Spirit"
+            [   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#43 - Drake Nest"
         , decks:
-            [ "Flame Demon"
-            , "Rending Drake"
-            , "Spitting Drake"
+            [   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Rending Drake", "deck_name": "Rending Drake" }
+            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
             ]
         },
         { name: "#44 Tribal Assault"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Hound"
-            , "Shaman"
+            [   {"name": "Inox Guard", "deck_name": "Guard" }
+            ,   {"name": "Inox Archer", "deck_name": "Archer" }
+            ,   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
             ]
         },
         { name: "#45 Rebel Swamp"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Hound"
+            [   {"name": "City Guard", "deck_name": "Guard" }
+            ,   {"name": "City Archer", "deck_name": "Archer" }
+            ,   {"name": "Hound", "deck_name": "Hound" }
             ]
         },
         { name: "#46 Nightmare Peak"
         , decks:
-            [ "Night Demon"
-            , "Frost Demon"
-            , "Wind Demon"
-            , "Savvas Icestorm"
-            , "Boss"
+            [   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "Savvas Icestorm", "deck_name": "Savvas Icestorm" }
+            ,   {"name": "Boss: Winged Horror", "deck_name": "Boss" }
             ]
         },
         { name: "#47 Lair of the Unseeing Eye"
         , decks:
-            [ "Lurker"
-            , "Deep Terror"
-            , "Harrower Infester"
-            , "Boss"
+            [   {"name": "Lurker", "deck_name": "Lurker" }
+            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
+            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
+            ,   {"name": "Boss: The Sightless Eye", "deck_name": "Boss" }
             ]
         },
         { name: "#48 - Shadow Weald"
         , decks:
-            [ "Imp"
-            , "Earth Demon"
-            , "Harrower Infester"
-            , "Boss"
+            [   {"name": "Imp", "deck_name": "Imp" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
+            ,   {"name": "Boss: Dark Rider", "deck_name": "Boss" }
             ]
         },
         { name: "#49 Rebel's Stand"
         , decks:
-            [ "Giant Viper"
-            , "Archer"
-            , "Guard"
-            , "Ancient Artillery"
+            [   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            ,   {"name": "City Archer", "deck_name": "Archer" }
+            ,   {"name": "City Guard", "deck_name": "Guard" }
+            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
             ]
         },
         { name: "#50 Ghost Fortress"
         , decks:
-            [ "Night Demon"
-            , "Sun Demon"
-            , "Earth Demon"
+            [   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
             ]
         },
         { name: "#51 The Void"
         , decks:
-            [ "Boss"
+            [   {"name": "Boss: The Gloom", "deck_name": "Boss" }
             ]
         },
         { name: "#52 Noxious Cellar"
         , decks:
-            [ "Spitting Drake"
-            , "Ooze"
-            , "Scout"
-            , "Living Corpse"
-            , "Shaman"
+            [   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
+            ,   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Vermling Scout", "deck_name": "Scout" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Vermling Shaman", "deck_name": "Shaman" }
             ]
         },
         { name: "#53 Crypt Basement"
         , decks:
-            [ "Ooze"
-            , "Living Corpse"
-            , "Living Spirit"
-            , "Living Bones"
-            , "Giant Viper"
+            [   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
             ]
         },
         { name: "#54 Palace of Ice"
         , decks:
-            [ "Cave Bear"
-            , "Living Spirit"
-            , "Frost Demon"
-            , "Harrower Infester"
+            [   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
             ]
         },
         //TODO Show message that this is random, use deck tab instead
@@ -442,314 +445,321 @@ SCENARIO_DEFINITIONS =
         },
         { name: "#56 Bandit's Wood"
         , decks:
-            [ "Hound"
-            , "Archer"
-            , "Rending Drake"
-            , "Guard"
+            [   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Bandit Archer", "deck_name": "Archer" }
+            ,   {"name": "Rending Drake", "deck_name": "Rending Drake" }
+            ,   {"name": "Bandit Guard", "deck_name": "Guard" }
             ]
         },
         { name: "#57 Investigation"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Hound"
+            [   {"name": "City Guard", "deck_name": "Guard" }
+            ,   {"name": "City Archer", "deck_name": "Archer" }
+            ,   {"name": "Hound", "deck_name": "Hound" }
             ]
         },
         { name: "#58 Bloody Shack"
         , decks:
-            [ "Earth Demon"
-            , "Harrower Infester"
-            , "Imp"
-            , "Guard"
+            [   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
+            ,   {"name": "Black Imp", "deck_name": "Imp" }
+            ,   {"name": "City Guard", "deck_name": "Guard" }
             ]
         },
         { name: "#59 Forgotten Grove"
         , decks:
-            [ "Cave Bear"
-            , "Hound"
-            , "Imp"
+            [   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            ,   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Forest Imp", "deck_name": "Imp" }
             ]
         },
         { name: "#60 Alchemy Lab"
         , decks:
-            [ "Ooze"
-            , "Giant Viper"
-            , "Hound"
-            , "Rending Drake"
-            , "Spitting Drake"
+            [   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            ,   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Rending Drake", "deck_name": "Rending Drake" }
+            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
             ]
         },
         { name: "#61 Fading Lighthouse"
         , decks:
-            [ "Ooze"
-            , "Giant Viper"
-            , "Frost Demon"
-            , "Flame Demon"
+            [   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
             ]
         },
         { name: "#62 Pit of Souls"
         , decks:
-            [ "Living Bones"
-            , "Living Spirit"
+            [   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#63 Magma Pit"
         , decks:
-            [ "Scout"
-            , "Guard"
-            , "Archer"
+            [   {"name": "Vermling Scout", "deck_name": "Scout" }
+            ,   {"name": "Inox Guard", "deck_name": "Guard" }
+            ,   {"name": "Inox Archer", "deck_name": "Archer" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
             ]
         },
         { name: "#64 Underwater Lagoon"
         , decks:
-            [ "Ooze"
-            , "Imp"
-            , "Rending Drake"
+            [   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Forest Imp", "deck_name": "Imp" }
+            ,   {"name": "Rending Drake", "deck_name": "Rending Drake" }
             ]
         },
         { name: "#65 Sulfur Mine"
         , decks:
-            [ "Scout"
-            , "Hound"
-            , "Shaman"
+            [   {"name": "Vermling Scout", "deck_name": "Scout" }
+            ,   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
             ]
         },
         { name: "#66 Clockwork Cove"
         , decks:
-            [ "Ooze"
-            , "Ancient Artillery"
-            , "Living Spirit"
-            , "Stone Golem"
+            [   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
             ]
         },
         { name: "#67 Arcane Library"
         , decks:
-            [ "Imp"
-            , "Cave Bear"
-            , "Stone Golem"
+            [   {"name": "Forest Imp", "deck_name": "Imp" }
+            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
             ]
         },
         { name: "#68 Toxic Moor"
         , decks:
-            [ "Rending Drake"
-            , "Imp"
-            , "Giant Viper"
-            , "Living Corpse"
+            [   {"name": "Rending Drake", "deck_name": "Rending Drake" }
+            ,   {"name": "Black Imp", "deck_name": "Imp" }
+            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
             ]
         },
         { name: "#69 Well of the Unfortunate"
         , decks:
-            [ "Scout"
-            , "Shaman"
-            , "Imp"
-            , "Stone Golem"
-            , "Living Spirit"
+            [   {"name": "Vermling Scout", "deck_name": "Scout" }
+            ,   {"name": "Vermling Shaman", "deck_name": "Shaman" }
+            ,   {"name": "Forest Imp", "deck_name": "Imp" }
+            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#70 Chained Isle"
         , decks:
-            [ "Night Demon"
-            , "Wind Demon"
-            , "Living Spirit"
+            [   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#71 Windswept Highlands"
         , decks:
-            [ "Spitting Drake"
-            , "Wind Demon"
-            , "Sun Demon"
+            [   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
             ]
         },
         { name: "#72 Oozing Grove"
         , decks:
-            [ "Ooze"
-            , "Imp"
-            , "Giant Viper"
+            [   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Forest Imp", "deck_name": "Imp" }
+            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
             ]
         },
         { name: "#73 Rockslide Ridge"
         , decks:
-            [ "Hound"
-            , "Archer"
-            , "Ancient Artillery"
-            , "Guard"
-            , "Shaman"
+            [   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Inox Archer", "deck_name": "Archer" }
+            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
+            ,   {"name": "Inox Guard", "deck_name": "Guard" }
+            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
             ]
         },
         { name: "#74 Merchant Ship"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Lurker"
-            , "Deep Terror"
+            [   {"name": "Bandit Guard", "deck_name": "Guard" }
+            ,   {"name": "Bandit Archer", "deck_name": "Archer" }
+            ,   {"name": "Lurker", "deck_name": "Lurker" }
+            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
             ]
         },
         { name: "#75 Overgrown Graveyard"
         , decks:
-            [ "Living Bones"
-            , "Living Corpse"
-            , "Living Spirit"
+            [   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#76 Harrower Hive"
         , decks:
-            [ "Giant Viper"
-            , "Living Bones"
-            , "Night Demon"
-            , "Harrower Infester"
+            [   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
             ]
         },
         { name: "#77 Vault of Secrets"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Stone Golem"
-            , "Hound"
+            [   {"name": "City Guard", "deck_name": "Guard" }
+            ,   {"name": "City Archer", "deck_name": "Archer" }
+            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            ,   {"name": "Hound", "deck_name": "Hound" }
             ]
         },
         { name: "#78 Sacrifice Pit"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Cultist"
-            , "Living Bones"
-            , "Imp"
+            [   {"name": "Bandit Guard", "deck_name": "Guard" }
+            ,   {"name": "Bandit Archer", "deck_name": "Archer" }
+            ,   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Black Imp", "deck_name": "Imp" }
             ]
         },
         { name: "#79 Lost Temple"
         , decks:
-            [ "Stone Golem"
-            , "Giant Viper"
-            , "Boss"
+            [   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            ,   {"name": "Boss: The Betrayer", "deck_name": "Boss" }
             ]
         },
         { name: "#80 Vigil Keep"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Ancient Artillery"
-            , "Hound"
+            [   {"name": "City Guard", "deck_name": "Guard" }
+            ,   {"name": "City Archer", "deck_name": "Archer" }
+            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
+            ,   {"name": "Hound", "deck_name": "Hound" }
             ]
         },
         { name: "#81 Temple of the Eclipse"
         , decks:
-            [ "Night Demon"
-            , "Sun Demon"
-            , "Stone Golem"
-            , "Ancient Artillery"
-            , "Boss"
+            [   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
+            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
+            ,   {"name": "Boss: The Colorless", "deck_name": "Boss" }
             ]
         },
         { name: "#82 Burning Mountain"
         , decks:
-            [ "Earth Demon"
-            , "Flame Demon"
-            , "Stone Golem"
+            [   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
             ]
         },
         { name: "#83 Shadows Within"
         , decks:
-            [ "Hound"
-            , "Cultist"
-            , "Living Bones"
-            , "Living Spirit"
-            , "Flame Demon"
+            [   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
             ]
         },
         { name: "#84 Crystalline Cave"
         , decks:
-            [ "Flame Demon"
-            , "Frost Demon"
-            , "Earth Demon"
+            [   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
             ]
         },
         { name: "#85 Sun Temple"
         , decks:
-            [ "Hound"
-            , "Imp"
-            , "Night Demon"
-            , "Sun Demon"
+            [   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Black Imp", "deck_name": "Imp" }
+            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
             ]
         },
         { name: "#86 Harried Village"
         , decks:
-            [ "Cave Bear"
-            , "Shaman"
-            , "Scout"
-            , "Lurker"
+            [   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            ,   {"name": "Vermling Shaman", "deck_name": "Shaman" }
+            ,   {"name": "Vermling Scout", "deck_name": "Scout" }
+            ,   {"name": "Lurker", "deck_name": "Lurker" }
             ]
         },
         { name: "#87 Corrupted Cove"
         , decks:
-            [ "Lurker"
-            , "Deep Terror"
-            , "Ooze"
-            , "Imp"
+            [   {"name": "Lurker", "deck_name": "Lurker" }
+            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
+            ,   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Black Imp", "deck_name": "Imp" }
             ]
         },
         { name: "#88 Plane of Water"
         , decks:
-            [ "Frost Demon"
-            , "Ooze"
-            , "Lurker"
+            [   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Ooze", "deck_name": "Ooze" }
+            ,   {"name": "Lurker", "deck_name": "Lurker" }
             ]
         },
         { name: "#89 Syndicate Hideout"
         , decks:
-            [ "Archer"
-            , "Guard"
-            , "Cultist"
-            , "Giant Viper"
+            [   {"name": "Bandit Archer", "deck_name": "Archer" }
+            ,   {"name": "Bandit Guard", "deck_name": "Guard" }
+            ,   {"name": "Cultist", "deck_name": "Cultist" }
+            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
             ]
         },
         { name: "#90 Demonic Rift"
         , decks:
-            [ "Earth Demon"
-            , "Wind Demon"
-            , "Night Demon"
-            , "Living Spirit"
+            [   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#91 Wild Melee"
         , decks:
-            [ "Cave Bear"
-            , "Hound"
-            , "Guard"
-            , "Archer"
-            , "Living Spirit"
+            [   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            ,   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Bandit Guard", "deck_name": "Guard" }
+            ,   {"name": "Bandit Archer", "deck_name": "Archer" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#92 Back Alley Brawl"
         , decks:
-            [ "Guard"
-            , "Archer"
-            , "Savvas Icestorm"
-            , "Frost Demon"
-            , "Wind Demon"
+            [   {"name": "Guard", "deck_name": "Guard" }
+            ,   {"name": "Archer", "deck_name": "Archer" }
+            ,   {"name": "Savvas Icestorm", "deck_name": "Savvas Icestorm" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            // TODO How are we going to display this? We have several guards/Archers
+            //,   {"name": "Bandit Guard", "deck_name": "Guard" }
+            //,   {"name": "Bandit Archer", "deck_name": "Archer" }
+            //,   {"name": "City Guard", "deck_name": "Guard" }
+            //,   {"name": "Inox Guard", "deck_name": "Guard" }
+            //,   {"name": "City Archer", "deck_name": "Archer" }
             ]
         },
         { name: "#93 Sunken Vessel"
         , decks:
-            [ "Lurker"
-            , "Frost Demon"
-            , "Living Spirit"
+            [   {"name": "Lurker", "deck_name": "Lurker" }
+            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
             ]
         },
         { name: "#94 Vermling Nest"
         , decks:
-            [ "Hound"
-            , "Scout"
-            , "Shaman"
-            , "Cave Bear"
+            [   {"name": "Hound", "deck_name": "Hound" }
+            ,   {"name": "Vermling Scout", "deck_name": "Scout" }
+            ,   {"name": "Vermling Shaman", "deck_name": "Shaman" }
+            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
             ]
         },
         { name: "#95 Payment Due"
         , decks:
-            [ "Deep Terror"
-            , "Flame Demon"
-            , "Earth Demon"
-            , "Savvas Lavaflow"
+            [   {"name": "Deep Terror", "deck_name": "Deep Terror" }
+            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            ,   {"name": "Savvas Lavaflow", "deck_name": "Savvas Lavaflow" }
             ]
-        },
+        }
 
     ];

--- a/scenarios.js
+++ b/scenarios.js
@@ -1,7 +1,7 @@
 //special_rules should be treated with some kind of macro that recognises them and applies them when loading
 SPECIAL_RULES =
 {
-    living_corpse_two_levels_extra: 
+    living_corpse_two_levels_extra:
         {   "description": "All living corpses are two levels higher than the scenario level, up to a max of 7",
             "affected_deck": "Living Corpse",
             "extra_levels": 2
@@ -19,224 +19,224 @@ SCENARIO_DEFINITIONS =
         },
         { name: "#2 Barrow Lair"
         , decks:
-            [   {"name": "Bandit Archer", "deck_name": "Archer" }
-            ,   {"name": "Boss: Bandit Commander", "deck_name": "Boss" }
-            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            [   {"name": "Bandit Archer"}
+            ,   {"name": "Boss: Bandit Commander"}
+            ,   {"name": "Living Bones"}
+            ,   {"name": "Living Corpse"}
             ]
         },
         { name: "#3 Inox Encampment"
         , decks:
-            [   {"name": "Inox Guard", "deck_name": "Guard" }
-            ,   {"name": "Inox Archer", "deck_name": "Archer" }
-            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
+            [   {"name": "Inox Guard"}
+            ,   {"name": "Inox Archer"}
+            ,   {"name": "Inox Shaman"}
             ]
         },
         { name: "#4 Crypt of the Damned"
         , decks:
-            [   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Bandit Archer", "deck_name": "Archer" }
-            ,   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            [   {"name": "Living Bones"}
+            ,   {"name": "Bandit Archer"}
+            ,   {"name": "Cultist"}
+            ,   {"name": "Earth Demon"}
+            ,   {"name": "Wind Demon"}
             ]
         },
         { name: "#5 Ruinous Crypt"
         , decks:
-            [   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            [   {"name": "Cultist"}
+            ,   {"name": "Living Bones"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "Night Demon"}
+            ,   {"name": "Flame Demon"}
+            ,   {"name": "Frost Demon"}
             ]
         },
         { name: "#6 Decaying Crypt"
         , decks:
-            [   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Living Bones"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#7 Vibrant Grotto"
         , decks:
-            [   {"name": "Forest Imp", "deck_name": "Imp" }
-            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
-            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            [   {"name": "Forest Imp"}
+            ,   {"name": "Cave Bear"}
+            ,   {"name": "Inox Shaman"}
+            ,   {"name": "Earth Demon"}
             ]
         },
         { name: "#8 Gloomhaven Warehouse"
         , decks:
-            [   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Boss: Inox Bodyguard", "deck_name": "Boss" }
+            [   {"name": "Living Bones"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "Boss: Inox Bodyguard"}
             ]
         },
         { name: "#9 Diamond Mine"
         , decks:
-            [   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Vermling Scout", "deck_name": "Scout" }
-            ,   {"name": "Boss: Merciless Overseer", "deck_name": "Boss" }
+            [   {"name": "Hound"}
+            ,   {"name": "Vermling Scout"}
+            ,   {"name": "Boss: Merciless Overseer"}
             ]
         },
         { name: "#10 Plane of Elemental Power"
         , decks:
-            [   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
+            [   {"name": "Flame Demon"}
+            ,   {"name": "Earth Demon"}
+            ,   {"name": "Sun Demon"}
             ]
         },
         { name: "#11 Gloomhaven Square A"
         , decks:
-            [   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "City Guard", "deck_name": "Guard" }
-            ,   {"name": "City Archer", "deck_name": "Archer" }
-            ,   {"name": "Boss: Captain of the Guard", "deck_name": "Boss" }
+            [   {"name": "Living Bones"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "City Guard"}
+            ,   {"name": "City Archer"}
+            ,   {"name": "Boss: Captain of the Guard"}
             ]
         },
         { name: "#12 Gloomhaven Square B"
         , decks:
-            [   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "City Guard", "deck_name": "Guard" }
-            ,   {"name": "City Archer", "deck_name": "Archer" }
-            ,   {"name": "Boss: Jekserah", "deck_name": "Boss" }
+            [   {"name": "Living Bones"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "Cultist"}
+            ,   {"name": "City Guard"}
+            ,   {"name": "City Archer"}
+            ,   {"name": "Boss: Jekserah"}
             ]
         },
         { name: "#13 Temple of the Seer"
         , decks:
-            [   {"name": "Stone Golem", "deck_name": "Stone Golem" }
-            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
-            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
+            [   {"name": "Stone Golem"}
+            ,   {"name": "Cave Bear"}
+            ,   {"name": "Living Spirit"}
+            ,   {"name": "Spitting Drake"}
             ]
         },
         { name: "#14 Frozen Hollow"
         , decks:
-            [   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
+            [   {"name": "Hound"}
+            ,   {"name": "Living Spirit"}
+            ,   {"name": "Frost Demon"}
             ]
         },
         { name: "#15 Shrine of Strength"
         , decks:
-            [   {"name": "Stone Golem", "deck_name": "Stone Golem" }
-            ,   {"name": "Savvas Icestorm", "deck_name": "Savvas Icestorm" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
+            [   {"name": "Stone Golem"}
+            ,   {"name": "Savvas Icestorm"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "Harrower Infester"}
             ]
         },
         { name: "#16 Mountain Pass"
         , decks:
-            [   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "Inox Guard", "deck_name": "Guard" }
-            ,   {"name": "Inox Archer", "deck_name": "Archer" }
+            [   {"name": "Earth Demon"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "Inox Guard"}
+            ,   {"name": "Inox Archer"}
             ]
         },
         { name: "#17 Lost Island"
         , decks:
-            [   {"name": "Vermling Scout", "deck_name": "Scout" }
-            ,   {"name": "Vermling Shaman", "deck_name": "Shaman" }
-            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            [   {"name": "Vermling Scout"}
+            ,   {"name": "Vermling Shaman"}
+            ,   {"name": "Cave Bear"}
             ]
         },
         { name: "#18 Abandoned Sewers"
         , decks:
-            [   {"name": "Giant Viper", "deck_name": "Giant Viper" }
-            ,   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Vermling Scout", "deck_name": "Scout" }
+            [   {"name": "Giant Viper"}
+            ,   {"name": "Ooze"}
+            ,   {"name": "Vermling Scout"}
             ]
         },
         { name: "#19 Forgotten Crypt"
         , decks:
-            [   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            [   {"name": "Cultist"}
+            ,   {"name": "Living Bones"}
+            ,   {"name": "Living Spirit"}
+            ,   {"name": "Living Corpse"}
             ]
         },
         { name: "#20 Necromancer's Sanctum"
         , decks:
-            [   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Boss: Jekserah", "deck_name": "Boss" }
+            [   {"name": "Living Bones"}
+            ,   {"name": "Cultist"}
+            ,   {"name": "Night Demon"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "Boss: Jekserah"}
             ]
         },
         { name: "#21 Infernal Throne"
         , decks:
-            [   {"name": "Sun Demon", "deck_name": "Sun Demon" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Boss: Prime Demon", "deck_name": "Boss" }
+            [   {"name": "Sun Demon"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Night Demon"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "Earth Demon"}
+            ,   {"name": "Flame Demon"}
+            ,   {"name": "Boss: Prime Demon"}
             ]
         },
         { name: "#22 Temple of the Elements"
         , decks:
-            [   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            [   {"name": "Living Bones"}
+            ,   {"name": "Cultist"}
+            ,   {"name": "Earth Demon"}
+            ,   {"name": "Flame Demon"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Wind Demon"}
             ]
         },
         { name: "#23 Deep Ruins"
         , decks:
-            [   {"name": "Stone Golem", "deck_name": "Stone Golem" }
-            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
-            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Stone Golem"}
+            ,   {"name": "Ancient Artillery"}
+            ,   {"name": "Living Bones"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#24 Echo Chamber"
         , decks:
-            [   {"name": "Rending Drake", "deck_name": "Rending Drake" }
-            ,   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Rending Drake"}
+            ,   {"name": "Ooze"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#25 Icecrag Ascent"
         , decks:
-            [   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Rending Drake", "deck_name": "Rending Drake" }
-            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
+            [   {"name": "Hound"}
+            ,   {"name": "Rending Drake"}
+            ,   {"name": "Spitting Drake"}
             ]
         },
         { name: "#26 Ancient Cistern"
         , decks:
-            [   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Black Imp", "deck_name": "Imp" }
+            [   {"name": "Living Corpse"}
+            ,   {"name": "Ooze"}
+            ,   {"name": "Night Demon"}
+            ,   {"name": "Black Imp"}
             ]
         },
         { name: "#27 Ruinous Rift"
         , decks:
-            [   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            [   {"name": "Night Demon"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Sun Demon"}
+            ,   {"name": "Earth Demon"}
+            ,   {"name": "Flame Demon"}
             ]
         },
         { name: "#28 Outer Ritual Chamber"
         , decks:
-            [   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
+            [   {"name": "Living Corpse"}
+            ,   {"name": "Cultist"}
+            ,   {"name": "Living Bones"}
+            ,   {"name": "Night Demon"}
+            ,   {"name": "Sun Demon"}
             ]
         , special_rules:
             [ SPECIAL_RULES.living_corpse_two_levels_extra
@@ -244,208 +244,208 @@ SCENARIO_DEFINITIONS =
         },
         { name: "#29 Sanctuary of Gloom"
         , decks:
-            [   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
-            ,   {"name": "Black Imp", "deck_name": "Imp" }
+            [   {"name": "Living Bones"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "Living Spirit"}
+            ,   {"name": "Black Imp"}
             ]
         },
         { name: "#30 Shrine of the Depths"
         , decks:
-            [   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Lurker", "deck_name": "Lurker" }
-            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
+            [   {"name": "Ooze"}
+            ,   {"name": "Lurker"}
+            ,   {"name": "Deep Terror"}
             ]
         },
         { name: "#31 Plane of the Night"
         , decks:
-            [   {"name": "Deep Terror", "deck_name": "Deep Terror" }
-            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Black Imp", "deck_name": "Imp" }
+            [   {"name": "Deep Terror"}
+            ,   {"name": "Night Demon"}
+            ,   {"name": "Black Imp"}
             ]
         },
         { name: "#32 Decrepit Wood"
         , decks:
-            [   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
-            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
-            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
-            ,   {"name": "Black Imp", "deck_name": "Imp" }
+            [   {"name": "Harrower Infester"}
+            ,   {"name": "Giant Viper"}
+            ,   {"name": "Deep Terror"}
+            ,   {"name": "Black Imp"}
             ]
         },
         { name: "#33 Savvas Armory"
         , decks:
-            [   {"name": "Savvas Icestorm", "deck_name": "Savvas Icestorm" }
-            ,   {"name": "Savvas Lavaflow", "deck_name": "Savvas Lavaflow" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            [   {"name": "Savvas Icestorm"}
+            ,   {"name": "Savvas Lavaflow"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Flame Demon"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "Earth Demon"}
             ]
         },
         { name: "#34 Scorched Summit"
         , decks:
-            [   {"name": "Rending Drake", "deck_name": "Rending Drake" }
-            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
-            ,   {"name": "Boss: Elder Drake", "deck_name": "Boss" }
+            [   {"name": "Rending Drake"}
+            ,   {"name": "Spitting Drake"}
+            ,   {"name": "Boss: Elder Drake"}
             ]
         },
         { name: "#35 Gloomhaven Battlements A"
         , decks:
-            [   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
+            [   {"name": "Flame Demon"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Earth Demon"}
+            ,   {"name": "Wind Demon"}
             ]
         },
         { name: "#36 Gloomhaven Battlements B"
         , decks:
-            [   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "City Archer", "deck_name": "Archer" }
-            ,   {"name": "Boss: Prime Demon", "deck_name": "Boss" }
+            [   {"name": "Flame Demon"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Earth Demon"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "City Archer"}
+            ,   {"name": "Boss: Prime Demon"}
             ]
         },
         { name: "#37 Doom Trench"
         , decks:
-            [   {"name": "Lurker", "deck_name": "Lurker" }
-            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
-            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
+            [   {"name": "Lurker"}
+            ,   {"name": "Deep Terror"}
+            ,   {"name": "Harrower Infester"}
             ]
         },
         { name: "#38 Slave Pens"
         , decks:
-            [   {"name": "Inox Guard", "deck_name": "Guard" }
-            ,   {"name": "Inox Archer", "deck_name": "Archer" }
-            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
-            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            [   {"name": "Inox Guard"}
+            ,   {"name": "Inox Archer"}
+            ,   {"name": "Inox Shaman"}
+            ,   {"name": "Stone Golem"}
             ]
         },
         { name: "#39 Treacherous Divide"
         , decks:
-            [   {"name": "Cave Bear", "deck_name": "Cave Bear" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
-            ,   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
+            [   {"name": "Cave Bear"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Spitting Drake"}
+            ,   {"name": "Cultist"}
+            ,   {"name": "Living Bones"}
             ]
         },
         { name: "#40 Ancient Defense Network"
         , decks:
-            [   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
-            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
-            ,   {"name": "Forest Imp", "deck_name": "Imp" }
+            [   {"name": "Living Corpse"}
+            ,   {"name": "Flame Demon"}
+            ,   {"name": "Cave Bear"}
+            ,   {"name": "Stone Golem"}
+            ,   {"name": "Forest Imp"}
             ]
         },
         { name: "#41 Timeworn Tomb"
         , decks:
-            [   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
-            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            [   {"name": "Ancient Artillery"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "Living Spirit"}
+            ,   {"name": "Stone Golem"}
             ]
         },
         { name: "#42 Realm of the Voice"
         , decks:
-            [   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Night Demon"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#43 - Drake Nest"
         , decks:
-            [   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Rending Drake", "deck_name": "Rending Drake" }
-            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
+            [   {"name": "Flame Demon"}
+            ,   {"name": "Rending Drake"}
+            ,   {"name": "Spitting Drake"}
             ]
         },
         { name: "#44 Tribal Assault"
         , decks:
-            [   {"name": "Inox Guard", "deck_name": "Guard" }
-            ,   {"name": "Inox Archer", "deck_name": "Archer" }
-            ,   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
+            [   {"name": "Inox Guard"}
+            ,   {"name": "Inox Archer"}
+            ,   {"name": "Hound"}
+            ,   {"name": "Inox Shaman"}
             ]
         },
         { name: "#45 Rebel Swamp"
         , decks:
-            [   {"name": "City Guard", "deck_name": "Guard" }
-            ,   {"name": "City Archer", "deck_name": "Archer" }
-            ,   {"name": "Hound", "deck_name": "Hound" }
+            [   {"name": "City Guard"}
+            ,   {"name": "City Archer"}
+            ,   {"name": "Hound"}
             ]
         },
         { name: "#46 Nightmare Peak"
         , decks:
-            [   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "Savvas Icestorm", "deck_name": "Savvas Icestorm" }
-            ,   {"name": "Boss: Winged Horror", "deck_name": "Boss" }
+            [   {"name": "Night Demon"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "Savvas Icestorm"}
+            ,   {"name": "Boss: Winged Horror"}
             ]
         },
         { name: "#47 Lair of the Unseeing Eye"
         , decks:
-            [   {"name": "Lurker", "deck_name": "Lurker" }
-            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
-            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
-            ,   {"name": "Boss: The Sightless Eye", "deck_name": "Boss" }
+            [   {"name": "Lurker"}
+            ,   {"name": "Deep Terror"}
+            ,   {"name": "Harrower Infester"}
+            ,   {"name": "Boss: The Sightless Eye"}
             ]
         },
         { name: "#48 - Shadow Weald"
         , decks:
-            [   {"name": "Forest Imp", "deck_name": "Imp" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
-            ,   {"name": "Boss: Dark Rider", "deck_name": "Boss" }
+            [   {"name": "Forest Imp"}
+            ,   {"name": "Earth Demon"}
+            ,   {"name": "Harrower Infester"}
+            ,   {"name": "Boss: Dark Rider"}
             ]
         },
         { name: "#49 Rebel's Stand"
         , decks:
-            [   {"name": "Giant Viper", "deck_name": "Giant Viper" }
-            ,   {"name": "City Archer", "deck_name": "Archer" }
-            ,   {"name": "City Guard", "deck_name": "Guard" }
-            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
+            [   {"name": "Giant Viper"}
+            ,   {"name": "City Archer"}
+            ,   {"name": "City Guard"}
+            ,   {"name": "Ancient Artillery"}
             ]
         },
         { name: "#50 Ghost Fortress"
         , decks:
-            [   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            [   {"name": "Night Demon"}
+            ,   {"name": "Sun Demon"}
+            ,   {"name": "Earth Demon"}
             ]
         },
         { name: "#51 The Void"
         , decks:
-            [   {"name": "Boss: The Gloom", "deck_name": "Boss" }
+            [   {"name": "Boss: The Gloom"}
             ]
         },
         { name: "#52 Noxious Cellar"
         , decks:
-            [   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
-            ,   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Vermling Scout", "deck_name": "Scout" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Vermling Shaman", "deck_name": "Shaman" }
+            [   {"name": "Spitting Drake"}
+            ,   {"name": "Ooze"}
+            ,   {"name": "Vermling Scout"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "Vermling Shaman"}
             ]
         },
         { name: "#53 Crypt Basement"
         , decks:
-            [   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
-            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            [   {"name": "Ooze"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "Living Spirit"}
+            ,   {"name": "Living Bones"}
+            ,   {"name": "Giant Viper"}
             ]
         },
         { name: "#54 Palace of Ice"
         , decks:
-            [   {"name": "Cave Bear", "deck_name": "Cave Bear" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
+            [   {"name": "Cave Bear"}
+            ,   {"name": "Living Spirit"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Harrower Infester"}
             ]
         },
         //TODO Show message that this is random, use deck tab instead
@@ -455,320 +455,317 @@ SCENARIO_DEFINITIONS =
         },
         { name: "#56 Bandit's Wood"
         , decks:
-            [   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Bandit Archer", "deck_name": "Archer" }
-            ,   {"name": "Rending Drake", "deck_name": "Rending Drake" }
-            ,   {"name": "Bandit Guard", "deck_name": "Guard" }
+            [   {"name": "Hound"}
+            ,   {"name": "Bandit Archer"}
+            ,   {"name": "Rending Drake"}
+            ,   {"name": "Bandit Guard"}
             ]
         },
         { name: "#57 Investigation"
         , decks:
-            [   {"name": "City Guard", "deck_name": "Guard" }
-            ,   {"name": "City Archer", "deck_name": "Archer" }
-            ,   {"name": "Hound", "deck_name": "Hound" }
+            [   {"name": "City Guard"}
+            ,   {"name": "City Archer"}
+            ,   {"name": "Hound"}
             ]
         },
         { name: "#58 Bloody Shack"
         , decks:
-            [   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
-            ,   {"name": "Black Imp", "deck_name": "Imp" }
-            ,   {"name": "City Guard", "deck_name": "Guard" }
+            [   {"name": "Earth Demon"}
+            ,   {"name": "Harrower Infester"}
+            ,   {"name": "Black Imp"}
+            ,   {"name": "City Guard"}
             ]
         },
         { name: "#59 Forgotten Grove"
         , decks:
-            [   {"name": "Cave Bear", "deck_name": "Cave Bear" }
-            ,   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Forest Imp", "deck_name": "Imp" }
+            [   {"name": "Cave Bear"}
+            ,   {"name": "Hound"}
+            ,   {"name": "Forest Imp"}
             ]
         },
         { name: "#60 Alchemy Lab"
         , decks:
-            [   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
-            ,   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Rending Drake", "deck_name": "Rending Drake" }
-            ,   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
+            [   {"name": "Ooze"}
+            ,   {"name": "Giant Viper"}
+            ,   {"name": "Hound"}
+            ,   {"name": "Rending Drake"}
+            ,   {"name": "Spitting Drake"}
             ]
         },
         { name: "#61 Fading Lighthouse"
         , decks:
-            [   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            [   {"name": "Ooze"}
+            ,   {"name": "Giant Viper"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Flame Demon"}
             ]
         },
         { name: "#62 Pit of Souls"
         , decks:
-            [   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Living Bones"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#63 Magma Pit"
         , decks:
-            [   {"name": "Vermling Scout", "deck_name": "Scout" }
-            ,   {"name": "Inox Guard", "deck_name": "Guard" }
-            ,   {"name": "Inox Archer", "deck_name": "Archer" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            [   {"name": "Vermling Scout"}
+            ,   {"name": "Inox Guard"}
+            ,   {"name": "Inox Archer"}
+            ,   {"name": "Flame Demon"}
             ]
         },
         { name: "#64 Underwater Lagoon"
         , decks:
-            [   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Forest Imp", "deck_name": "Imp" }
-            ,   {"name": "Rending Drake", "deck_name": "Rending Drake" }
+            [   {"name": "Ooze"}
+            ,   {"name": "Forest Imp"}
+            ,   {"name": "Rending Drake"}
             ]
         },
         { name: "#65 Sulfur Mine"
         , decks:
-            [   {"name": "Vermling Scout", "deck_name": "Scout" }
-            ,   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
+            [   {"name": "Vermling Scout"}
+            ,   {"name": "Hound"}
+            ,   {"name": "Inox Shaman"}
             ]
         },
         { name: "#66 Clockwork Cove"
         , decks:
-            [   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
-            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            [   {"name": "Ooze"}
+            ,   {"name": "Ancient Artillery"}
+            ,   {"name": "Living Spirit"}
+            ,   {"name": "Stone Golem"}
             ]
         },
         { name: "#67 Arcane Library"
         , decks:
-            [   {"name": "Forest Imp", "deck_name": "Imp" }
-            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
-            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            [   {"name": "Forest Imp"}
+            ,   {"name": "Cave Bear"}
+            ,   {"name": "Stone Golem"}
             ]
         },
         { name: "#68 Toxic Moor"
         , decks:
-            [   {"name": "Rending Drake", "deck_name": "Rending Drake" }
-            ,   {"name": "Black Imp", "deck_name": "Imp" }
-            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
+            [   {"name": "Rending Drake"}
+            ,   {"name": "Black Imp"}
+            ,   {"name": "Giant Viper"}
+            ,   {"name": "Living Corpse"}
             ]
         },
         { name: "#69 Well of the Unfortunate"
         , decks:
-            [   {"name": "Vermling Scout", "deck_name": "Scout" }
-            ,   {"name": "Vermling Shaman", "deck_name": "Shaman" }
-            ,   {"name": "Forest Imp", "deck_name": "Imp" }
-            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Vermling Scout"}
+            ,   {"name": "Vermling Shaman"}
+            ,   {"name": "Forest Imp"}
+            ,   {"name": "Stone Golem"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#70 Chained Isle"
         , decks:
-            [   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Night Demon"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#71 Windswept Highlands"
         , decks:
-            [   {"name": "Spitting Drake", "deck_name": "Spitting Drake" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
+            [   {"name": "Spitting Drake"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "Sun Demon"}
             ]
         },
         { name: "#72 Oozing Grove"
         , decks:
-            [   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Forest Imp", "deck_name": "Imp" }
-            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            [   {"name": "Ooze"}
+            ,   {"name": "Forest Imp"}
+            ,   {"name": "Giant Viper"}
             ]
         },
         { name: "#73 Rockslide Ridge"
         , decks:
-            [   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Inox Archer", "deck_name": "Archer" }
-            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
-            ,   {"name": "Inox Guard", "deck_name": "Guard" }
-            ,   {"name": "Inox Shaman", "deck_name": "Shaman" }
+            [   {"name": "Hound"}
+            ,   {"name": "Inox Archer"}
+            ,   {"name": "Ancient Artillery"}
+            ,   {"name": "Inox Guard"}
+            ,   {"name": "Inox Shaman"}
             ]
         },
         { name: "#74 Merchant Ship"
         , decks:
-            [   {"name": "Bandit Guard", "deck_name": "Guard" }
-            ,   {"name": "Bandit Archer", "deck_name": "Archer" }
-            ,   {"name": "Lurker", "deck_name": "Lurker" }
-            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
+            [   {"name": "Bandit Guard"}
+            ,   {"name": "Bandit Archer"}
+            ,   {"name": "Lurker"}
+            ,   {"name": "Deep Terror"}
             ]
         },
         { name: "#75 Overgrown Graveyard"
         , decks:
-            [   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Corpse", "deck_name": "Living Corpse" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Living Bones"}
+            ,   {"name": "Living Corpse"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#76 Harrower Hive"
         , decks:
-            [   {"name": "Giant Viper", "deck_name": "Giant Viper" }
-            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Harrower Infester", "deck_name": "Harrower Infester" }
+            [   {"name": "Giant Viper"}
+            ,   {"name": "Living Bones"}
+            ,   {"name": "Night Demon"}
+            ,   {"name": "Harrower Infester"}
             ]
         },
         { name: "#77 Vault of Secrets"
         , decks:
-            [   {"name": "City Guard", "deck_name": "Guard" }
-            ,   {"name": "City Archer", "deck_name": "Archer" }
-            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
-            ,   {"name": "Hound", "deck_name": "Hound" }
+            [   {"name": "City Guard"}
+            ,   {"name": "City Archer"}
+            ,   {"name": "Stone Golem"}
+            ,   {"name": "Hound"}
             ]
         },
         { name: "#78 Sacrifice Pit"
         , decks:
-            [   {"name": "Bandit Guard", "deck_name": "Guard" }
-            ,   {"name": "Bandit Archer", "deck_name": "Archer" }
-            ,   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Black Imp", "deck_name": "Imp" }
+            [   {"name": "Bandit Guard"}
+            ,   {"name": "Bandit Archer"}
+            ,   {"name": "Cultist"}
+            ,   {"name": "Living Bones"}
+            ,   {"name": "Black Imp"}
             ]
         },
         { name: "#79 Lost Temple"
         , decks:
-            [   {"name": "Stone Golem", "deck_name": "Stone Golem" }
-            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
-            ,   {"name": "Boss: The Betrayer", "deck_name": "Boss" }
+            [   {"name": "Stone Golem"}
+            ,   {"name": "Giant Viper"}
+            ,   {"name": "Boss: The Betrayer"}
             ]
         },
         { name: "#80 Vigil Keep"
         , decks:
-            [   {"name": "City Guard", "deck_name": "Guard" }
-            ,   {"name": "City Archer", "deck_name": "Archer" }
-            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
-            ,   {"name": "Hound", "deck_name": "Hound" }
+            [   {"name": "City Guard"}
+            ,   {"name": "City Archer"}
+            ,   {"name": "Ancient Artillery"}
+            ,   {"name": "Hound"}
             ]
         },
         { name: "#81 Temple of the Eclipse"
         , decks:
-            [   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
-            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
-            ,   {"name": "Ancient Artillery", "deck_name": "Ancient Artillery" }
-            ,   {"name": "Boss: The Colorless", "deck_name": "Boss" }
+            [   {"name": "Night Demon"}
+            ,   {"name": "Sun Demon"}
+            ,   {"name": "Stone Golem"}
+            ,   {"name": "Ancient Artillery"}
+            ,   {"name": "Boss: The Colorless"}
             ]
         },
         { name: "#82 Burning Mountain"
         , decks:
-            [   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Stone Golem", "deck_name": "Stone Golem" }
+            [   {"name": "Earth Demon"}
+            ,   {"name": "Flame Demon"}
+            ,   {"name": "Stone Golem"}
             ]
         },
         { name: "#83 Shadows Within"
         , decks:
-            [   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "Living Bones", "deck_name": "Living Bones" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
+            [   {"name": "Hound"}
+            ,   {"name": "Cultist"}
+            ,   {"name": "Living Bones"}
+            ,   {"name": "Living Spirit"}
+            ,   {"name": "Flame Demon"}
             ]
         },
         { name: "#84 Crystalline Cave"
         , decks:
-            [   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
+            [   {"name": "Flame Demon"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Earth Demon"}
             ]
         },
         { name: "#85 Sun Temple"
         , decks:
-            [   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Black Imp", "deck_name": "Imp" }
-            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Sun Demon", "deck_name": "Sun Demon" }
+            [   {"name": "Hound"}
+            ,   {"name": "Black Imp"}
+            ,   {"name": "Night Demon"}
+            ,   {"name": "Sun Demon"}
             ]
         },
         { name: "#86 Harried Village"
         , decks:
-            [   {"name": "Cave Bear", "deck_name": "Cave Bear" }
-            ,   {"name": "Vermling Shaman", "deck_name": "Shaman" }
-            ,   {"name": "Vermling Scout", "deck_name": "Scout" }
-            ,   {"name": "Lurker", "deck_name": "Lurker" }
+            [   {"name": "Cave Bear"}
+            ,   {"name": "Vermling Shaman"}
+            ,   {"name": "Vermling Scout"}
+            ,   {"name": "Lurker"}
             ]
         },
         { name: "#87 Corrupted Cove"
         , decks:
-            [   {"name": "Lurker", "deck_name": "Lurker" }
-            ,   {"name": "Deep Terror", "deck_name": "Deep Terror" }
-            ,   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Black Imp", "deck_name": "Imp" }
+            [   {"name": "Lurker"}
+            ,   {"name": "Deep Terror"}
+            ,   {"name": "Ooze"}
+            ,   {"name": "Black Imp"}
             ]
         },
         { name: "#88 Plane of Water"
         , decks:
-            [   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Ooze", "deck_name": "Ooze" }
-            ,   {"name": "Lurker", "deck_name": "Lurker" }
+            [   {"name": "Frost Demon"}
+            ,   {"name": "Ooze"}
+            ,   {"name": "Lurker"}
             ]
         },
         { name: "#89 Syndicate Hideout"
         , decks:
-            [   {"name": "Bandit Archer", "deck_name": "Archer" }
-            ,   {"name": "Bandit Guard", "deck_name": "Guard" }
-            ,   {"name": "Cultist", "deck_name": "Cultist" }
-            ,   {"name": "Giant Viper", "deck_name": "Giant Viper" }
+            [   {"name": "Bandit Archer"}
+            ,   {"name": "Bandit Guard"}
+            ,   {"name": "Cultist"}
+            ,   {"name": "Giant Viper"}
             ]
         },
         { name: "#90 Demonic Rift"
         , decks:
-            [   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            ,   {"name": "Night Demon", "deck_name": "Night Demon" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Earth Demon"}
+            ,   {"name": "Wind Demon"}
+            ,   {"name": "Night Demon"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#91 Wild Melee"
         , decks:
-            [   {"name": "Cave Bear", "deck_name": "Cave Bear" }
-            ,   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Bandit Guard", "deck_name": "Guard" }
-            ,   {"name": "Bandit Archer", "deck_name": "Archer" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Cave Bear"}
+            ,   {"name": "Hound"}
+            ,   {"name": "Bandit Guard"}
+            ,   {"name": "Bandit Archer"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#92 Back Alley Brawl"
         , decks:
-            [   {"name": "Guard", "deck_name": "Guard" }
-            ,   {"name": "Archer", "deck_name": "Archer" }
-            ,   {"name": "Savvas Icestorm", "deck_name": "Savvas Icestorm" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Wind Demon", "deck_name": "Wind Demon" }
-            // TODO How are we going to display this? We have several guards/Archers
-            //,   {"name": "Bandit Guard", "deck_name": "Guard" }
-            //,   {"name": "Bandit Archer", "deck_name": "Archer" }
-            //,   {"name": "City Guard", "deck_name": "Guard" }
-            //,   {"name": "Inox Guard", "deck_name": "Guard" }
-            //,   {"name": "City Archer", "deck_name": "Archer" }
+            [   {"name": "Bandit Guard"}
+            ,   {"name": "City Guard"}
+            ,   {"name": "Inox Guard"}
+            ,   {"name": "Bandit Archer"}
+            ,   {"name": "City Archer"}
+            ,   {"name": "Savvas Icestorm"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Wind Demon"}
             ]
         },
         { name: "#93 Sunken Vessel"
         , decks:
-            [   {"name": "Lurker", "deck_name": "Lurker" }
-            ,   {"name": "Frost Demon", "deck_name": "Frost Demon" }
-            ,   {"name": "Living Spirit", "deck_name": "Living Spirit" }
+            [   {"name": "Lurker"}
+            ,   {"name": "Frost Demon"}
+            ,   {"name": "Living Spirit"}
             ]
         },
         { name: "#94 Vermling Nest"
         , decks:
-            [   {"name": "Hound", "deck_name": "Hound" }
-            ,   {"name": "Vermling Scout", "deck_name": "Scout" }
-            ,   {"name": "Vermling Shaman", "deck_name": "Shaman" }
-            ,   {"name": "Cave Bear", "deck_name": "Cave Bear" }
+            [   {"name": "Hound"}
+            ,   {"name": "Vermling Scout"}
+            ,   {"name": "Vermling Shaman"}
+            ,   {"name": "Cave Bear"}
             ]
         },
         { name: "#95 Payment Due"
         , decks:
-            [   {"name": "Deep Terror", "deck_name": "Deep Terror" }
-            ,   {"name": "Flame Demon", "deck_name": "Flame Demon" }
-            ,   {"name": "Earth Demon", "deck_name": "Earth Demon" }
-            ,   {"name": "Savvas Lavaflow", "deck_name": "Savvas Lavaflow" }
+            [   {"name": "Deep Terror"}
+            ,   {"name": "Flame Demon"}
+            ,   {"name": "Earth Demon"}
+            ,   {"name": "Savvas Lavaflow"}
             ]
         }
 

--- a/style.css
+++ b/style.css
@@ -137,5 +137,3 @@ ul.tabcontainer .inactive
     cursor:             pointer;
     z-index:            1;
 }
-
-.force-redraw::before { content: "" }

--- a/style.css
+++ b/style.css
@@ -137,3 +137,5 @@ ul.tabcontainer .inactive
     cursor:             pointer;
     z-index:            1;
 }
+
+.force-redraw::before { content: "" }

--- a/util.js
+++ b/util.js
@@ -80,3 +80,8 @@ function input_value(input)
 {
     return (('value' in input) ? input.value : '');
 }
+
+function remove_empty_strings(array)
+{
+    return array.filter(Boolean);
+}

--- a/util.js
+++ b/util.js
@@ -85,3 +85,13 @@ function remove_empty_strings(array)
 {
     return array.filter(Boolean);
 }
+
+function clone(obj)
+{
+    if (null == obj || "object" != typeof obj) return obj;
+    var copy = obj.constructor();
+    for (var attr in obj) {
+        if (obj.hasOwnProperty(attr)) copy[attr] = obj[attr];
+    }
+    return copy;
+}

--- a/util.js
+++ b/util.js
@@ -63,6 +63,7 @@ function dict_values(dict)
     for (key in dict) {
         values.push(dict[key]);
     }
+    
     return values;
 }
 
@@ -84,14 +85,4 @@ function input_value(input)
 function remove_empty_strings(array)
 {
     return array.filter(Boolean);
-}
-
-function clone(obj)
-{
-    if (null == obj || "object" != typeof obj) return obj;
-    var copy = obj.constructor();
-    for (var attr in obj) {
-        if (obj.hasOwnProperty(attr)) copy[attr] = obj[attr];
-    }
-    return copy;
 }


### PR DESCRIPTION
This is not ready to be merged yet, it's missing at least:

- If we fix End_of_round, having multiple Guard decks have issues with it. Although before fixing End_of_round, we have to find a way to disable decks. I really like that functionality, but if all the Living Bones are dead... we should maintain them in the same state!
- Finding an easier way to select the level on the deck tab. Maybe selecting the general level and then adding/substracting some... instead of having to click a lot of times for every deck.

It also requires some refactor and cleaning, as I haven't started with that. That's why I would thank some feedback and review, in case I should redo some parts before leaving everything clean!

Thanks!

Feel free to use https://ginogalotti.github.io/gloomycompanion/?monster-stat to test it
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johreh/gloomycompanion/42)
<!-- Reviewable:end -->
