### PR TITLE
Move -webkit-clip-path above clip-path to fix precedence

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -339,15 +339,15 @@
 .card.modifier.front.left img.cover
 {
     left:                       -25%;
-    clip-path:                  inset(0% 24.5% 0% 24.5%);
     -webkit-clip-path:          inset(0% 24.5% 0% 24.5%);
+    clip-path:                  inset(0% 24.5% 0% 24.5%);
 }
 
 .card.modifier.front.right img.cover
 {
     left:                       25%;
-    clip-path:                  inset(0% 24.5% 0% 24.5%);
     -webkit-clip-path:          inset(0% 24.5% 0% 24.5%);
+    clip-path:                  inset(0% 24.5% 0% 24.5%);
 }
 
 .card ul


### PR DESCRIPTION
@GinoGalotti Please review. The vendor-prefixed property needs to come before the non-prefixed property for correct precedence to apply (preferring standard when implemented by the browser).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johreh/gloomycompanion/43)
<!-- Reviewable:end -->
