### PR TITLE
added checkbox to show/hide modifier deck

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,11 +30,14 @@
                     <li id="deckstab">Decks</li>
                 </ul>
                 <div id="scenariospage" class="tabbody">
+                    <input id="showmodifierdeck" type="checkbox" checked /><label for="showmodifierdeck">Show Monster Modifier Deck</label>
+                    <br>
                     <input id="applyscenario" type="button" value="Apply" />
                     <br>
                     <input id="applyload" type="button" value="Load Previous Scenario" />
                 </div>
                 <div id="deckspage" class="tabbody">
+                    <input id="showmodifierdeck-deckspage" type="checkbox" checked /><label for="showmodifierdeck-deckspage">Show Monster Modifier Deck</label>
                     <input id="applydecks" type="button" value="Apply" />
                 </div>
             </div>

--- a/logic.js
+++ b/logic.js
@@ -1058,6 +1058,7 @@ function init() {
     var applydeckbtn = document.getElementById("applydecks");
     var applyscenariobtn = document.getElementById("applyscenario");
     var applyloadbtn = document.getElementById("applyload");
+    var showmodifierdeck = document.getElementById("showmodifierdeck");
 
     var decklist = new DeckList();
     var scenariolist = new ScenarioList(SCENARIO_DEFINITIONS);
@@ -1073,6 +1074,14 @@ function init() {
             return load_ability_deck(deck_names.class, deck_names.name, deck_names.level);
         });
         apply_deck_selection(selected_decks, true);
+        var showmodifierdeck_deckspage = document.getElementById("showmodifierdeck-deckspage");
+        var modifier_deck_section = document.getElementById("modifier-container");
+        if(!showmodifierdeck_deckspage.checked){
+            modifier_deck_section.style.display = "none";
+        }
+        else{
+            modifier_deck_section.style.display = "block";
+        }
     };
 
     applyscenariobtn.onclick = function () {
@@ -1084,6 +1093,13 @@ function init() {
             return load_ability_deck(deck_names.class, deck_names.name, deck_names.level);
         });
         apply_deck_selection(selected_decks, false);
+        var modifier_deck_section = document.getElementById("modifier-container");
+        if(!showmodifierdeck.checked){
+            modifier_deck_section.style.display = "none";
+        }
+        else{
+            modifier_deck_section.style.display = "block";
+        }
     };
 
     applyloadbtn.onclick = function () {
@@ -1093,7 +1109,13 @@ function init() {
             return load_ability_deck(deck_names.class, deck_names.name, deck_names.level);
         });
         apply_deck_selection(selected_decks, true);
-
+        var modifier_deck_section = document.getElementById("modifier-container");
+        if(!showmodifierdeck.checked){
+            modifier_deck_section.style.display = "none";
+        }
+        else{
+            modifier_deck_section.style.display = "block";
+        }
     }
 
     window.onresize = refresh_ui.bind(null, visible_ability_decks);


### PR DESCRIPTION
My group prefers to use the physical monster modifier deck, so I added a checkbox to toggle it (on both the scenariospage and deckspage).