### PR TITLE
Update Boss Special 2 For Scenario 34

### DIFF
--- a/monster_stats.js
+++ b/monster_stats.js
@@ -6712,7 +6712,7 @@ MONSTER_STATS = {
             "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
-            "%move% and summon 2 Zephyrs"
+            "Summon 2 Zephyrs and %move%"
           ],
           "immunities": [
             "%wound%",
@@ -6733,7 +6733,7 @@ MONSTER_STATS = {
             "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
-            "%move% and summon 2 Zephyrs"
+            "Summon 2 Zephyrs and %move%"
           ],
           "immunities": [
             "%wound%",
@@ -6754,7 +6754,7 @@ MONSTER_STATS = {
             "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
-            "%move% and summon 2 Zephyrs"
+            "Summon 2 Zephyrs and %move%"
           ],
           "immunities": [
             "%wound%",
@@ -6775,7 +6775,7 @@ MONSTER_STATS = {
             "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
-            "%move% and summon 2 Zephyrs"
+            "Summon 2 Zephyrs and %move%"
           ],
           "immunities": [
             "%wound%",
@@ -6796,7 +6796,7 @@ MONSTER_STATS = {
             "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
-            "%move% and summon 2 Zephyrs"
+            "Summon 2 Zephyrs and %move%"
           ],
           "immunities": [
             "%wound%",
@@ -6817,7 +6817,7 @@ MONSTER_STATS = {
             "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
-            "%move% and summon 2 Zephyrs"
+            "Summon 2 Zephyrs and %move%"
           ],
           "immunities": [
             "%wound%",
@@ -6838,7 +6838,7 @@ MONSTER_STATS = {
             "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
-            "%move% and summon 2 Zephyrs"
+            "Summon 2 Zephyrs and %move%"
           ],
           "immunities": [
             "%wound%",
@@ -6859,7 +6859,7 @@ MONSTER_STATS = {
             "%attack% +0 %boss-aoe-elder-drake-sp1%"
           ],
           "special2": [
-            "%move% and summon 2 Zephyrs"
+            "Summon 2 Zephyrs and %move%"
           ],
           "immunities": [
             "%wound%",


### PR DESCRIPTION
Scenario 34 has the boss special's actions reversed. Instead of moving first, the summon should occur first.

From Page 45 of the Second Edition Scenario book:

> The Elder Drake summons two Zephyrs, represented by numbered tokens, then flies to the next perch of boulders in the order ...