### PR TITLE
Fix special AOE image loading in MS Edge

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -371,7 +371,7 @@
     margin:                     0 2ch;
     padding-top:                2.5em;
     box-sizing:                 border-box;
-    overflow:                   hidden;
+    overflow:                   visible; /* hidden would be nicer, but for rare layouts or large AOE images better to show even overlfowing off the card, than to cut it off completely as it is vital information */
 
     display:                    -webkit-box;
     -webkit-box-orient:         vertical;
@@ -451,7 +451,7 @@ div.collapse
 {
     display:                    inline-block;
     width:                      0;
-    height:                     0;
+    height:                     1px; /* can't be 0 or MS Edge hides the whole div; sigh */
 }
 
 .element


### PR DESCRIPTION
The MS Edge browser will hide the entire "collapse" image if the height is set to 0. This changes the collapse to height:1px so it doesn't affect layout flow (significantly) but still shows the image in all modern browsers.

Additionally, it also allows overflow of images past card boundaries. This only affects certain screen widths, but when it does, it crops the edge of AOE images just a little in all browsers. The rest of the elements all still fit in the container though, so nothing else is affected by this overflow switch from hidden->visible.